### PR TITLE
[Self-Evolution] Strengthen 01_backend_feature.yml + add Phase 2 readiness gates to STATE

### DIFF
--- a/.agentic/STATE.md
+++ b/.agentic/STATE.md
@@ -51,4 +51,9 @@ Phase 1 (Foundation & Database Layer) — implementation complete, pending Phase
 * Set app.tenant_id session variable per database client in DatabaseModule.
 * Add integration/E2E tests (Supertest against live NestJS app).
 * Review ADR-0001 with stakeholders and get formal sign-off.
-* Begin Phase 2: Workflow Control Plane.
+
+## Phase 2 readiness gates (block implementation start)
+* [ ] Phase 1b closed (all bullets above checked off).
+* [ ] Self-evolution #39 merged — `01_backend_feature.yml` strengthened so future phase issues are born meeting Definition of Ready.
+* [ ] ADR-0002 (Workflow Control Plane) drafted with all 11 open questions resolved in the options table, `Status: Accepted` recorded by `rinzler-vicky`. Tracked by the ADR-0002 child issue under #25.
+* [ ] Then: begin Phase 2 implementation per the child issues linked from #25 (execution order: 2.1 schema → 2.2 compiler / 2.3 n8n adapter (parallel) → 2.4 lifecycle+proposal API → 2.5 execution+streaming+previews+failure-hook).

--- a/.github/ISSUE_TEMPLATE/01_backend_feature.yml
+++ b/.github/ISSUE_TEMPLATE/01_backend_feature.yml
@@ -52,7 +52,7 @@ body:
     id: reuse_pointers
     attributes:
       label: Reuse pointers
-      description: File paths of existing utilities, services, schema patterns, or modules that this work must reuse rather than reimplement. Pulled from current repo observations during planning.
+      description: File paths of existing utilities, services, schema patterns, or modules that this work must reuse rather than reimplement. Identify these from current repo observations during planning.
       placeholder: "- `backend/src/database/...` — shared pg pool\n- `backend/src/...` — describe reuse"
     validations:
       required: true
@@ -61,7 +61,7 @@ body:
     attributes:
       label: Rollback plan
       description: How is this phase rolled back if it must be reverted? Feature flag, paired migration-down per PR, PITR window, etc.
-      placeholder: "- Feature flag: describe flag name and removal plan\n- Migrations: each PR ships its own down step\n- DB recovery window: describe PITR or snapshot strategy"
+      placeholder: "- Feature flag: describe flag name and removal plan\n- Migrations: each PR ships its own down step\n- PITR window: describe recovery window or snapshot strategy"
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/01_backend_feature.yml
+++ b/.github/ISSUE_TEMPLATE/01_backend_feature.yml
@@ -18,13 +18,66 @@ body:
     validations:
       required: true
   - type: textarea
+    id: problem_statement
+    attributes:
+      label: Problem statement
+      description: What user, developer, or operational need does this phase address? Why is it being done now?
+    validations:
+      required: true
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: Explicit out-of-scope items. Helps the implementer avoid scope creep and signals what is deferred to later phases.
+      value: |
+        -
+    validations:
+      required: true
+  - type: textarea
+    id: hard_prerequisites
+    attributes:
+      label: Hard prerequisites (block-on)
+      description: Gates that must be closed before any implementation PR for this phase may merge. Reference prior phases, ADRs, infrastructure provisioning, etc.
+      value: |
+        - [ ]
+    validations:
+      required: true
+  - type: textarea
     id: architecture
     attributes:
       label: Approved architecture / ADR link
-      description: Link ADR or summarize approved design. If not approved, this issue is not ready.
-      placeholder: "ADR-0001 or N/A with reason"
+      description: Link the ADR file path (e.g., `docs/adr/ADR-0002-...md`). The ADR must be `Status: Accepted` before any implementation PR for this phase merges.
+      placeholder: "docs/adr/ADR-0002-... — Status: Accepted | Proposed | N/A with reason"
     validations:
       required: true
+  - type: textarea
+    id: reuse_pointers
+    attributes:
+      label: Reuse pointers
+      description: File paths of existing utilities, services, schema patterns, or modules that this work must reuse rather than reimplement. Pulled from current repo observations during planning.
+      value: |
+        - `backend/src/...` —
+    validations:
+      required: true
+  - type: textarea
+    id: rollback_plan
+    attributes:
+      label: Rollback plan
+      description: How is this phase rolled back if it must be reverted? Feature flag, paired migration-down per PR, PITR window, etc.
+      value: |
+        - Feature flag:
+        - Migrations: each PR ships its own down step
+        - DB recovery window:
+    validations:
+      required: true
+  - type: textarea
+    id: self_modification_surface
+    attributes:
+      label: Self-modification surface (optional)
+      description: For phases that touch the governed-mutation model (ARCHITECTURE.md §3), which mutation Class (A/B/C/D) does this work enable or constrain? Leave blank if not applicable.
+      placeholder: "e.g., Phase 2 ships the Class C mechanism (agent-authored drafts); Phase 5 layers Class D approval policy."
+    validations:
+      required: false
   - type: textarea
     id: surfaces
     attributes:


### PR DESCRIPTION
## Summary

- Adds five required textareas to `.github/ISSUE_TEMPLATE/01_backend_feature.yml` (problem_statement, non_goals, hard_prerequisites, reuse_pointers, rollback_plan) plus one optional field (self_modification_surface) so future backend-phase issues are born meeting AGENTS.md Definition of Ready.
- Strengthens the existing architecture-link field description: ADR must be `Status: Accepted` before any implementation PR merges.
- Appends Phase 2 readiness gates to `.agentic/STATE.md` so the gating is visible to every future agent session.

## Why

Planning of #25 (Phase 2 tracker) revealed that the existing template is what produced its thin body in the first place. Strengthening #25 alone leaves the next phase issue equally thin. This is a durable fix authorized by the maintainer on 2026-05-17.

## Refs

- Self-evolution issue: #39
- Phase 2 tracker (the one that exposed the gap): #25
- Phase 2 child issues this enables: #40 (ADR-0002), #41 (schema), #42 (compiler), #43 (n8n), #44 (lifecycle + proposal API), #45 (execution + previews)

## Changed surfaces

- `.github/ISSUE_TEMPLATE/01_backend_feature.yml` — six fields added, one description strengthened
- `.agentic/STATE.md` — Phase 2 readiness gates section appended

## Validation evidence

- YAML structure: edits add new `type: textarea` blocks alongside existing ones; no fields renamed or removed.
- STATE.md: gates list references real issue numbers (#39, #40) and ties back to `AGENTS.md` §Phase plan rule.

## Risks

Very low. The template only affects new issues opened via the GitHub UI template selector; existing issues are unaffected. STATE.md change is documentation only.

## Rollback

`git revert <commit>`. No runtime impact, no data migration.

## Test plan

- [ ] Open a draft issue using the **01 — Backend Feature Phase** template via GitHub UI; confirm all six new fields render with their default values and the required ones reject empty submission.
- [ ] Confirm `.agentic/STATE.md` renders cleanly on GitHub.

## Note to reviewer

Do NOT merge until you have reviewed the strengthened template fields and the new STATE.md gates section. This PR is the gate for the Phase 2 child issues to begin executing.