### PR TITLE
fix(infra): replace corepack enable with corepack pnpm form + auto-label PRs

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -30,15 +30,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Apply render-preview label (gates Render Dashboard preview creation)
+      - name: Apply render-preview label (PR tracking; previews auto-created by Render Blueprint)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          gh pr edit "${PR_NUMBER}" --repo "${REPO}" --add-label render-preview \
-            || echo "::warning::Could not apply render-preview label (already present or transient API error); continuing."
+          gh pr edit "${PR_NUMBER}" --repo "${REPO}" --add-label render-preview
 
       - name: Compute Neon branch expiration (14 days)
         id: neon_expiry

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -30,6 +30,16 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Apply render-preview label (gates Render Dashboard preview creation)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh pr edit "${PR_NUMBER}" --repo "${REPO}" --add-label render-preview \
+            || echo "::warning::Could not apply render-preview label (already present or transient API error); continuing."
+
       - name: Compute Neon branch expiration (14 days)
         id: neon_expiry
         run: echo "expires_at=$(date -u --date '+14 days' +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"

--- a/render.yaml
+++ b/render.yaml
@@ -42,7 +42,7 @@ services:
     plan: starter
     region: oregon
     rootDir: .
-    buildCommand: corepack enable && pnpm install --frozen-lockfile && pnpm --filter @agent/backend build
+    buildCommand: corepack pnpm install --frozen-lockfile && corepack pnpm --filter @agent/backend build
     startCommand: pnpm --filter @agent/backend start
     healthCheckPath: /v1/health
     autoDeploy: true


### PR DESCRIPTION
## Summary
- Replace `corepack enable && pnpm ...` with `corepack pnpm ...` in `render.yaml` — fixes EROFS on Render's Node 24.14.1 image where `/usr/bin/pnpm` is read-only
- Auto-apply `render-preview` label as the first workflow step in `pr-preview.yml` — eliminates the manual label dance

## Why
PR #48's Render build crashed at `2026-05-17T07:50:40Z`:
```
Internal Error: EROFS: read-only file system, unlink '/usr/bin/pnpm'
==> Build failed 😞
```
`corepack enable` tries to overwrite the system-installed pnpm shim and gets EROFS. The `corepack <pm> <args>` form ([documented here](https://github.com/nodejs/corepack#utility-commands)) runs `pnpm@10.33.2` (pinned in root `package.json`) without writing any shims.

The label auto-apply step uses `gh pr edit --add-label` with `GITHUB_TOKEN`. `GITHUB_TOKEN` actions don't recurse (per [Triggering a workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow)), so there's no `labeled`-event re-fire loop. Existing `permissions: pull-requests: write` covers the call.

## Test plan
- [x] Verify the diff is exactly two surgical changes (no other knobs touched)
- [ ] **Draft check**: while this PR is a draft, `pr-preview.yml` should skip its main job (existing `if: draft == false` guard). Label should NOT yet appear.
- [ ] **Ready check**: mark this PR ready for review; within ~10–15 s the new step should run and `render-preview` label appears without manual action.
- [ ] **Render build check**: build log should NOT contain `EROFS`. `pnpm install --frozen-lockfile` and `pnpm --filter @agent/backend build` should both run via the corepack proxy.
- [ ] **End-to-end**: preview comes up at `/v1/health` returning 200; PR gets the combined Neon+preview comment.

## Out of scope
- No `DISCOVER_MAX_ATTEMPTS` bump
- No discovery filter widening
- No diagnostic dumps
- No Render-API fallback creator

These were considered and explicitly rejected. Known follow-up risk: if Render's preview slot doesn't appear in their API within the 3-min discovery window, the workflow still fails even though the preview itself builds. Re-run via `gh workflow run` or empty commit recovers it. Will address if it happens in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)