### PR TITLE
[Phase 2.5a] Execution engine + SSE + failure hook (#45 backend split)

### DIFF
--- a/.agentic/STATE.md
+++ b/.agentic/STATE.md
@@ -1,12 +1,14 @@
 status: IN_PROGRESS
-current_phase: 2.4
+current_phase: 2.5a
 active_domain: backend
 
 # AGENT STATE TRACKER
 This file serves as the hot memory. Read at the start of every execution; update before opening a Pull Request.
 
 ## Current Objective
-Phase 2.4 (#44 — Workflow Lifecycle and Proposal API) — implementation complete; PR open against `main`. Unit + service specs pass (176/176); integration tests parse and require `DATABASE_URL` in CI.
+Phase 2.5a (#45 split — backend execution engine + SSE + cooperative cancel + failure→proposal hook) — implementation complete; PR open against `main`. 216/216 unit tests pass. Typecheck + swagger clean. The CI/branch-preview pipeline + agent-worker drain are split into follow-up sub-issues per the user's "deferred = sub-issue" rule.
+
+Phase 2.4 (#44) merged in PR #64.
 Phase 1b — pending Neon provisioning and integration test execution.
 
 ## Decisions Made
@@ -22,6 +24,10 @@ Phase 1b — pending Neon provisioning and integration test execution.
 * PR Preview Environments (initial): Docker-based deployment with GHCR for container registry, Render deployment integration with manual PR preview mode. **Superseded by ADR-0002** — see below.
 * **ADR-0002 (proposed, 2026-05-17)**: Render Blueprint (`render.yaml`) + Neon database branching for ephemeral previews. GitHub is source of truth for service shape. `JWT_SECRET` is declared with `generateValue: true` so Render generates per-service secrets atomically — eliminates the imperative-API-patch race that broke PR #36. Per-PR Neon branches via `neondatabase/create-branch-action@v6`. GHCR Docker build removed (was unused by Render).
 * **ADR-0002 Workflow Control Plane (proposed, 2026-05-17)**: Phase 2 execution and proposal schema decisions finalized. Lifecycle state on workflow_versions (not separate drafts table), proposal metadata as columns (not 1:1 table), Neon branch per preview, n8n queue mode with Redis, execution_engine discriminator on workflow_runs, SSE + LISTEN/NOTIFY for events, proposal_triggers table for failure hooks, simple role:admin gate for Phase 2 publish.
+* **Phase 2.5a — n8n cancel is cooperative, not REST-driven (2026-05-18)**: n8n v1.79.0's `POST /executions/:id/stop` returns 404 in self-hosted ([n8n-io/n8n#14748](https://github.com/n8n-io/n8n/issues/14748)). Mitigation: compiler injects `__cancel_check_<id>` IF after each `__pre_*` ping; webhook handler returns `{cancelled}` flag derived from `workflow_runs.status`. Backend cancel endpoint flips DB state; the very next per-step ping short-circuits to `__end_cancelled`. Race window between cancel and the next ping is acceptable; guard `workflow_runs` transitions with `WHERE status NOT IN ('cancelled','succeeded','failed')` so a stray `workflow.completed` can't overwrite cancel.
+* **Phase 2.5a — n8n trigger via `POST /api/v1/workflows/:id/run` (2026-05-18)**: Confirmed against the n8n community thread. Compiler's `MANUAL_TRIGGER` node receives `{runId, tenantId, input}` from the call body; pre-pings extract via `$('__trigger').item.json.*`. Response `executionId` is best-effort; on omission we fall back to `GET /executions?workflowId&limit=1`.
+* **Phase 2.5a — single LISTEN client, two consumers (2026-05-18)**: `SseSubscriberService` owns the only long-lived `pg.Client` for `LISTEN run_events` and re-emits payloads on an in-process `EventEmitter`. `FailureHookService` listens on that emitter rather than opening a second connection. Multi-pod idempotency: advisory lock per run id + partial unique index on `proposal_triggers` (migration 013).
+* **Phase 2.5a — production frontend SSE auth deferred to Phase 6 (2026-05-18)**: Native browser `EventSource` cannot send `Authorization` headers ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/EventSource)). Backend integration tests use the Node `eventsource` package which supports headers; the production frontend will need cookie-JWT or one-shot signed URLs.
 
 ## Completed Tasks
 * Created backend/docs directory for comprehensive system documentation.
@@ -48,6 +54,12 @@ Phase 1b — pending Neon provisioning and integration test execution.
 * Created backend/scripts/migrate.js: simple migration runner tracking applied migrations in schema_migrations table. Updated in Phase 2.1 to support multiple rollback files (012_rollback_phase_2_1.sql, 006_rollback_down.sql).
 * Created backend/.env.example with all documented env vars. Updated in Phase 2.1 with WORKFLOW_CONTROL_PLANE_ENABLED flag, Redis, n8n, and Neon API configuration.
 * 24/24 unit tests passing (health, tenants, audit, auth, storage services).
+* **Phase 2.5a (Execution Engine + SSE + Failure Hook) — Issue #45 (split):**
+  - Migration 013: AFTER INSERT trigger on `run_events` publishing a compact `pg_notify('run_events', ...)` payload (run/tenant/sequence/event_type/step_run_id/event_id). Partial unique index on `proposal_triggers` (workflow_run_id, COALESCE(step_run_id, zero-uuid), error_fingerprint) WHERE status='pending'. `backend/scripts/migrate.js` updated.
+  - `backend/src/runs/`: new `RunsModule` with `POST/GET/cancel/events` routes. `RunsService` does the txn dance (INSERT → adapter trigger → stash provider id → audit → COMMIT). `SseSubscriberService` owns a dedicated `pg.Client` for `LISTEN run_events` and an in-process `EventEmitter` bridge. `FailureHookService` filters `workflow.failed`, reconciles via `N8nApiClient.getExecution`, walks per-node `runData`, writes one `proposal_triggers` row per failed node with the partial-index ON CONFLICT DO NOTHING guard.
+  - `backend/src/workflows/adapters/n8n/`: `N8nExecutionAdapter` (trigger only, no hard cancel). `N8nApiClient` adds `runWorkflow` and `listExecutions`. `n8n-compiler.ts` injects `__cancel_check_<id>` IF v2 after each `__pre_*` ping and a single shared `__end_cancelled` HTTP Request sink. Webhook controller's response now carries `{cancelled}`; new `workflow.cancelled` event handled idempotently; all `workflow_runs` status transitions guarded with `WHERE status NOT IN ('cancelled','succeeded','failed')`.
+  - 216/216 unit tests pass (40 new across the slice). Typecheck + swagger + lint clean. Wiki updated with the run lifecycle section, SSE reconnect contract, cooperative-cancel mechanics, failure-hook chain.
+  - Deferred to sub-issues (per user's "deferred = sub-issue" rule): branch-preview CI pipeline + agent-initiated previews (Phase 2.5b), agent worker that drains `proposal_triggers`, explicit n8n main-process restart resilience test, production-frontend SSE auth pattern (Phase 6), hard-cancel once n8n REST stop ships.
 * **Phase 2.4 (Workflow Lifecycle and Proposal API) — Issue #44:**
   - Added human draft + lifecycle controller (`WorkflowsController`) for `POST /v1/workflows`, `PATCH /v1/workflows/:id`, `POST /v1/workflows/:id/validate`, `POST /v1/workflows/:id/publish` (admin), `POST /v1/workflows/:id/rollback` (admin), `GET /v1/workflows/:id/diff`.
   - Added agent-facing `ProposalsController` for `POST /v1/workflow-proposals` (service-account JWT + `workflows:propose` scope; 30/min rate limit). Lands draft `workflow_versions` with `proposal_source='failure_recovery'` when `stepRunId` provided, `'agent_reflection'` otherwise. Audit event `workflow.proposal.created` links failing step → new draft via `resource_id`.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -38,6 +38,16 @@ N8N_WEBHOOK_SECRET=change-me-in-production-min-32-chars
 N8N_WEBHOOK_CLOCK_SKEW_S=300
 N8N_RECONCILE_TIMEOUT_MS=2000
 
+# n8n execution adapter (Phase 2.5a): timeout for POST /workflows/:id/run,
+# and the delay before falling back to GET /executions when the run response
+# arrives without an executionId.
+N8N_TRIGGER_TIMEOUT_MS=10000
+N8N_TRIGGER_LIST_FALLBACK_DELAY_MS=500
+
+# SSE event stream (Phase 2.5a): heartbeat interval that keeps reverse-proxy
+# connections alive during long-running workflows.
+SSE_HEARTBEAT_MS=15000
+
 # Neon API (for preview environment provisioning)
 NEON_API_KEY=
 NEON_PROJECT_ID=

--- a/backend/db/migrations/013_rollback_down.sql
+++ b/backend/db/migrations/013_rollback_down.sql
@@ -1,0 +1,4 @@
+-- Rollback for migration 013 (Phase 2.5a)
+DROP TRIGGER IF EXISTS run_events_notify ON run_events;
+DROP FUNCTION IF EXISTS notify_run_event();
+DROP INDEX IF EXISTS idx_proposal_triggers_pending_dedupe;

--- a/backend/db/migrations/013_rollback_down.sql
+++ b/backend/db/migrations/013_rollback_down.sql
@@ -2,3 +2,4 @@
 DROP TRIGGER IF EXISTS run_events_notify ON run_events;
 DROP FUNCTION IF EXISTS notify_run_event();
 DROP INDEX IF EXISTS idx_proposal_triggers_pending_dedupe;
+DROP INDEX IF EXISTS idx_run_events_event_id_dedupe;

--- a/backend/db/migrations/013_run_events_notify_trigger.sql
+++ b/backend/db/migrations/013_run_events_notify_trigger.sql
@@ -1,0 +1,41 @@
+-- Migration 013: NOTIFY trigger on run_events + idempotency index on proposal_triggers (Phase 2.5a)
+-- See ADR-0002 §Decision 7 (SSE + LISTEN/NOTIFY) and §Decision 8 (proposal_triggers failure hook).
+
+-- Trigger function: publishes a compact payload (<8 KB Postgres NOTIFY cap)
+-- whenever a row is appended to run_events. The payload carries the run/tenant
+-- ids and the sequence so the receiver can fetch the full row under the
+-- correct RLS scope. AFTER INSERT ordering matters: the existing
+-- next_event_sequence() BEFORE trigger must have already populated NEW.sequence.
+CREATE OR REPLACE FUNCTION notify_run_event() RETURNS TRIGGER AS $$
+DECLARE
+  v_tenant UUID;
+BEGIN
+  SELECT tenant_id INTO v_tenant FROM workflow_runs WHERE id = NEW.run_id;
+  PERFORM pg_notify(
+    'run_events',
+    json_build_object(
+      'run_id', NEW.run_id,
+      'tenant_id', v_tenant,
+      'sequence', NEW.sequence,
+      'event_type', NEW.event_type,
+      'step_run_id', NEW.step_run_id,
+      'event_id', NEW.id
+    )::text
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER run_events_notify
+  AFTER INSERT ON run_events
+  FOR EACH ROW EXECUTE FUNCTION notify_run_event();
+
+-- Idempotency index for the failure → proposal_triggers hook.
+-- Multiple backend pods all receive the same NOTIFY; the failure hook uses an
+-- advisory lock for in-flight dedupe, but the index survives pod restarts.
+-- Partial WHERE status='pending' keeps the index small (resolved triggers don't
+-- need uniqueness — the same fingerprint may legitimately re-fire after a
+-- prior proposal landed).
+CREATE UNIQUE INDEX idx_proposal_triggers_pending_dedupe
+  ON proposal_triggers (workflow_run_id, COALESCE(step_run_id, '00000000-0000-0000-0000-000000000000'::uuid), error_fingerprint)
+  WHERE status = 'pending';

--- a/backend/db/migrations/013_run_events_notify_trigger.sql
+++ b/backend/db/migrations/013_run_events_notify_trigger.sql
@@ -6,11 +6,24 @@
 -- ids and the sequence so the receiver can fetch the full row under the
 -- correct RLS scope. AFTER INSERT ordering matters: the existing
 -- next_event_sequence() BEFORE trigger must have already populated NEW.sequence.
+--
+-- SECURITY DEFINER + pinned search_path:
+-- The lookup against workflow_runs would otherwise inherit the inserting
+-- session's RLS context. Any insert path that forgets `set_config('app.tenant_id', ...)`
+-- (e.g. a future system-level reconcile job) would resolve v_tenant to NULL
+-- and the SSE/failure-hook consumers would silently drop the event (Copilot
+-- review PR #65). DEFINER bypasses RLS for the tenant lookup only; the trigger
+-- function does not insert or expose anything beyond what the inserting role
+-- already had access to. Hard-failing on NULL keeps misuse loud rather than
+-- silent.
 CREATE OR REPLACE FUNCTION notify_run_event() RETURNS TRIGGER AS $$
 DECLARE
   v_tenant UUID;
 BEGIN
   SELECT tenant_id INTO v_tenant FROM workflow_runs WHERE id = NEW.run_id;
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'notify_run_event: workflow_runs.tenant_id not found for run_id=%', NEW.run_id;
+  END IF;
   PERFORM pg_notify(
     'run_events',
     json_build_object(
@@ -24,7 +37,7 @@ BEGIN
   );
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, public;
 
 CREATE TRIGGER run_events_notify
   AFTER INSERT ON run_events
@@ -36,6 +49,17 @@ CREATE TRIGGER run_events_notify
 -- Partial WHERE status='pending' keeps the index small (resolved triggers don't
 -- need uniqueness — the same fingerprint may legitimately re-fire after a
 -- prior proposal landed).
+--
+-- The COALESCE expression is wrapped in parens so the matching
+-- `ON CONFLICT (...)` clause in INSERTs parses it as an index_expression
+-- (per PG `INSERT ... ON CONFLICT` grammar — Copilot review PR #65).
 CREATE UNIQUE INDEX idx_proposal_triggers_pending_dedupe
-  ON proposal_triggers (workflow_run_id, COALESCE(step_run_id, '00000000-0000-0000-0000-000000000000'::uuid), error_fingerprint)
+  ON proposal_triggers (workflow_run_id, (COALESCE(step_run_id, '00000000-0000-0000-0000-000000000000'::uuid)), error_fingerprint)
   WHERE status = 'pending';
+
+-- Functional index for the n8n-webhook dedup probe
+-- (`WHERE event_data->>'event_id' = $1`). Without this, every webhook
+-- delivery scans the run_events table; with the new failure-hook in Phase
+-- 2.5a, webhook traffic grows with run count (Gemini review PR #65).
+CREATE INDEX idx_run_events_event_id_dedupe
+  ON run_events ((event_data->>'event_id'));

--- a/backend/scripts/migrate.js
+++ b/backend/scripts/migrate.js
@@ -46,7 +46,7 @@ async function run() {
     } else if (direction === 'down') {
       console.log('  ▼  Running down migration...');
       // Run rollback migrations in reverse order
-      const rollbackFiles = ['012_rollback_phase_2_1_down.sql', '006_rollback_down.sql'];
+      const rollbackFiles = ['013_rollback_down.sql', '012_rollback_phase_2_1_down.sql', '006_rollback_down.sql'];
       for (const file of rollbackFiles) {
         const filePath = path.join(migrationsDir, file);
         if (fs.existsSync(filePath)) {

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { TenantsModule } from './tenants/tenants.module';
 import { AuditModule } from './audit/audit.module';
 import { StorageModule } from './storage/storage.module';
 import { WorkflowsModule } from './workflows/workflows.module';
+import { RunsModule } from './runs/runs.module';
 import { TenantMiddleware } from './auth/tenant.middleware';
 
 // WorkflowsModule is imported unconditionally so SwaggerModule can reflect
@@ -33,6 +34,7 @@ import { TenantMiddleware } from './auth/tenant.middleware';
     AuditModule,
     StorageModule,
     WorkflowsModule,
+    RunsModule,
   ],
   providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],
 })

--- a/backend/src/runs/failure-hook.service.spec.ts
+++ b/backend/src/runs/failure-hook.service.spec.ts
@@ -1,0 +1,211 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventEmitter } from 'events';
+import { FailureHookService, extractFailedNodes } from './failure-hook.service';
+import { SseSubscriberService } from './sse-subscriber.service';
+import { N8nApiClient } from '@/workflows/adapters/n8n/n8n-api.client';
+import { AuditService } from '@/audit/audit.service';
+import { DATABASE_POOL } from '@/database/database.module';
+
+const RUN = '11111111-1111-1111-1111-111111111111';
+const TENANT = '22222222-2222-2222-2222-222222222222';
+const STEP_RUN = '33333333-3333-3333-3333-333333333333';
+const PROVIDER_EXEC = 'n8n-exec-abc';
+
+interface MockClient {
+  query: jest.Mock;
+  release: jest.Mock;
+}
+
+const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+const buildService = async (overrides?: {
+  lockAcquired?: boolean;
+  providerExecutionId?: string | null;
+  executionData?: unknown;
+  stepRunId?: string | null;
+  conflictOnInsert?: boolean;
+}): Promise<{
+  service: FailureHookService;
+  subscriber: SseSubscriberService;
+  api: { getExecution: jest.Mock };
+  audit: { log: jest.Mock };
+  queries: Array<{ sql: string; params: any[] }>;
+}> => {
+  const queries: Array<{ sql: string; params: any[] }> = [];
+  const lockAcquired = overrides?.lockAcquired ?? true;
+  const providerExecutionId =
+    overrides?.providerExecutionId === undefined ? PROVIDER_EXEC : overrides.providerExecutionId;
+  const stepRunId = overrides?.stepRunId === undefined ? STEP_RUN : overrides.stepRunId;
+  const conflict = overrides?.conflictOnInsert ?? false;
+
+  const client: MockClient = {
+    query: jest.fn().mockImplementation((sql: string, params?: any[]) => {
+      queries.push({ sql, params: params ?? [] });
+      if (sql.includes('pg_try_advisory_xact_lock')) {
+        return Promise.resolve({ rows: [{ acquired: lockAcquired }] });
+      }
+      if (sql.startsWith('SELECT input FROM workflow_runs')) {
+        return Promise.resolve({
+          rows: [{
+            input: providerExecutionId
+              ? { __provider: { providerExecutionId } }
+              : {},
+          }],
+        });
+      }
+      if (sql.includes('FROM step_runs WHERE workflow_run_id')) {
+        return Promise.resolve({ rows: stepRunId ? [{ id: stepRunId }] : [] });
+      }
+      if (sql.includes("event_type = 'step.completed'")) {
+        return Promise.resolve({
+          rows: [{ event_data: { payload: { output: { checkpoint: 'yes' } } } }],
+        });
+      }
+      if (sql.startsWith('INSERT INTO proposal_triggers')) {
+        return Promise.resolve({ rows: conflict ? [] : [{ id: 'pt-1' }] });
+      }
+      return Promise.resolve({ rows: [] });
+    }),
+    release: jest.fn(),
+  };
+  const pool = { connect: jest.fn().mockResolvedValue(client) };
+  const subscriber: SseSubscriberService = {
+    notifications: new EventEmitter(),
+  } as unknown as SseSubscriberService;
+  const api = {
+    getExecution: jest.fn().mockResolvedValue({ data: overrides?.executionData ?? null }),
+  };
+  const audit = { log: jest.fn().mockResolvedValue(undefined) };
+
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      FailureHookService,
+      { provide: DATABASE_POOL, useValue: pool },
+      { provide: SseSubscriberService, useValue: subscriber },
+      { provide: N8nApiClient, useValue: api },
+      { provide: AuditService, useValue: audit },
+    ],
+  }).compile();
+  const service = module.get(FailureHookService);
+  service.onModuleInit();
+  return { service, subscriber, api, audit, queries };
+};
+
+describe('extractFailedNodes', () => {
+  it('returns one entry per node with an error on its last attempt', () => {
+    const data = {
+      resultData: {
+        runData: {
+          step_a: [{}], // no error
+          step_b: [{ error: { name: 'Boom', message: 'kaboom' } }],
+          step_c: [{}, { error: { message: 'second-attempt failed' } }],
+        },
+      },
+    };
+    const result = extractFailedNodes(data);
+    expect(result).toEqual([
+      { nodeName: 'step_b', error: { name: 'Boom', message: 'kaboom' } },
+      { nodeName: 'step_c', error: { name: 'NodeExecutionError', message: 'second-attempt failed' } },
+    ]);
+  });
+
+  it('returns [] for missing/empty runData', () => {
+    expect(extractFailedNodes(undefined)).toEqual([]);
+    expect(extractFailedNodes({})).toEqual([]);
+    expect(extractFailedNodes({ resultData: { runData: {} } })).toEqual([]);
+  });
+});
+
+describe('FailureHookService', () => {
+  const emitFailedEvent = (subscriber: SseSubscriberService) =>
+    subscriber.notifications.emit('event', {
+      run_id: RUN,
+      tenant_id: TENANT,
+      sequence: 9,
+      event_type: 'workflow.failed',
+      step_run_id: null,
+      event_id: 'evt-9',
+    });
+
+  it('ignores non-failure events', async () => {
+    const { subscriber, api } = await buildService();
+    subscriber.notifications.emit('event', {
+      run_id: RUN, tenant_id: TENANT, sequence: 1,
+      event_type: 'step.completed', step_run_id: null, event_id: 'evt-1',
+    });
+    await flush();
+    expect(api.getExecution).not.toHaveBeenCalled();
+  });
+
+  it('skips when another pod holds the advisory lock', async () => {
+    const { subscriber, api, audit, queries } = await buildService({ lockAcquired: false });
+    emitFailedEvent(subscriber);
+    await flush(); await flush();
+    expect(api.getExecution).not.toHaveBeenCalled();
+    expect(audit.log).not.toHaveBeenCalled();
+    // COMMIT runs even on skip
+    expect(queries.some((q) => q.sql === 'COMMIT')).toBe(true);
+  });
+
+  it('audits + skips when workflow_runs has no providerExecutionId', async () => {
+    const { subscriber, api, audit, queries } = await buildService({ providerExecutionId: null });
+    emitFailedEvent(subscriber);
+    await flush(); await flush();
+    expect(api.getExecution).not.toHaveBeenCalled();
+    expect(audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'failure_hook.skipped_no_provider_id' }),
+      expect.anything(),
+    );
+    expect(queries.some((q) => q.sql.startsWith('INSERT INTO proposal_triggers'))).toBe(false);
+  });
+
+  it('inserts one proposal_triggers row per failed node and audits each', async () => {
+    const { subscriber, api, audit, queries } = await buildService({
+      executionData: {
+        resultData: {
+          runData: {
+            step_a: [{ error: { name: 'E1', message: 'fail-a' } }],
+            step_b: [{ error: { name: 'E2', message: 'fail-b' } }],
+          },
+        },
+      },
+    });
+    emitFailedEvent(subscriber);
+    await flush(); await flush(); await flush();
+
+    expect(api.getExecution).toHaveBeenCalledWith(PROVIDER_EXEC);
+    const inserts = queries.filter((q) => q.sql.startsWith('INSERT INTO proposal_triggers'));
+    expect(inserts).toHaveLength(2);
+    expect(audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'workflow.run.failure_trigger_created' }),
+      expect.anything(),
+    );
+    expect(audit.log.mock.calls.filter((c) => c[0].action === 'workflow.run.failure_trigger_created'))
+      .toHaveLength(2);
+  });
+
+  it('falls back to a single trigger with no step_run_id when n8n returns no per-node data', async () => {
+    const { subscriber, audit, queries } = await buildService({ executionData: null });
+    emitFailedEvent(subscriber);
+    await flush(); await flush();
+
+    const inserts = queries.filter((q) => q.sql.startsWith('INSERT INTO proposal_triggers'));
+    expect(inserts).toHaveLength(1);
+    // stepRunId is the 3rd parameter (1-indexed: tenant, run, step_run, fp, ctx)
+    expect(inserts[0].params[2]).toBeNull();
+    expect(audit.log).toHaveBeenCalled();
+  });
+
+  it('skips audit when the INSERT is a no-op (ON CONFLICT DO NOTHING)', async () => {
+    const { subscriber, audit } = await buildService({
+      conflictOnInsert: true,
+      executionData: {
+        resultData: { runData: { step_a: [{ error: { name: 'E1', message: 'x' } }] } },
+      },
+    });
+    emitFailedEvent(subscriber);
+    await flush(); await flush();
+    // Only the skipped-no-provider_id case ever audits; conflict path audits nothing
+    expect(audit.log).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/runs/failure-hook.service.ts
+++ b/backend/src/runs/failure-hook.service.ts
@@ -165,11 +165,16 @@ export class FailureHookService implements OnModuleInit {
     // (migration 013) covers the (workflow_run_id, step_run_id,
     // error_fingerprint) tuple for status='pending'. ON CONFLICT DO NOTHING
     // makes the insert idempotent without throwing.
+    // ON CONFLICT must match the partial unique index expression in migration
+    // 013 exactly: the COALESCE is wrapped in parens so the parser treats it
+    // as an index_expression rather than a bare column ref. The trailing
+    // `WHERE status='pending'` infers the matching partial index per
+    // PG INSERT...ON CONFLICT grammar.
     const res = await client.query(
       `INSERT INTO proposal_triggers
             (tenant_id, workflow_run_id, step_run_id, error_fingerprint, trigger_context, status)
          VALUES ($1, $2, $3, $4, $5, 'pending')
-         ON CONFLICT (workflow_run_id, COALESCE(step_run_id, '00000000-0000-0000-0000-000000000000'::uuid), error_fingerprint)
+         ON CONFLICT (workflow_run_id, (COALESCE(step_run_id, '00000000-0000-0000-0000-000000000000'::uuid)), error_fingerprint)
             WHERE status = 'pending'
          DO NOTHING
          RETURNING id`,
@@ -259,5 +264,8 @@ export function extractFailedNodes(data: N8nExecutionData | undefined): FailedNo
 }
 
 function fingerprint(name: string, message: string): string {
-  return createHash('sha1').update(`${name}:${message}`).digest('hex').slice(0, 16);
+  // SHA-256 (64-bit truncated to 16 hex chars). The fingerprint is a dedupe
+  // key, not a security primitive, but SHA-256 aligns with modern hashing
+  // defaults (Gemini review PR #65) and is no slower in practice.
+  return createHash('sha256').update(`${name}:${message}`).digest('hex').slice(0, 16);
 }

--- a/backend/src/runs/failure-hook.service.ts
+++ b/backend/src/runs/failure-hook.service.ts
@@ -1,0 +1,263 @@
+import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Pool, PoolClient } from 'pg';
+import { createHash } from 'crypto';
+import { DATABASE_POOL } from '@/database/database.module';
+import { AuditService } from '@/audit/audit.service';
+import { N8nApiClient } from '@/workflows/adapters/n8n/n8n-api.client';
+import { SseSubscriberService, NotifyPayload } from './sse-subscriber.service';
+
+interface N8nNodeRunData {
+  error?: { message?: string; name?: string; description?: string };
+  data?: unknown;
+}
+
+interface N8nExecutionData {
+  resultData?: {
+    runData?: Record<string, N8nNodeRunData[]>;
+  };
+}
+
+/**
+ * Phase 2.5a failure → proposal hook.
+ *
+ * Subscribes to the in-process EventEmitter exposed by SseSubscriberService
+ * (so we share the single LISTEN connection — see comment on
+ * SseSubscriberService). Filters for `workflow.failed` events that carry a
+ * tenant + run id (the audit-only error-workflow path is skipped).
+ *
+ * For each qualifying failure:
+ *   1. Takes a `pg_try_advisory_xact_lock` on `('proposal_trigger_failed:' + run_id)`
+ *      so a multi-pod deployment doesn't write duplicate triggers. The
+ *      partial unique index on `proposal_triggers` (migration 013) covers
+ *      the cross-restart case.
+ *   2. Fetches the n8n execution detail via N8nApiClient.getExecution(),
+ *      walks `data.resultData.runData` for per-node `error`, and matches
+ *      each failed node to a `step_runs` row via `step_key === nodeName`.
+ *   3. Computes a small error_fingerprint (sha1 of `name:message`,
+ *      truncated to 16 hex chars) and looks up the most recent successful
+ *      step's output as `last_successful_checkpoint`.
+ *   4. INSERTs one row into `proposal_triggers` per failed node (status
+ *      'pending'). The agent worker that drains this queue is deferred to
+ *      a follow-up sub-issue.
+ *   5. Audits `workflow.run.failure_trigger_created` per row.
+ */
+@Injectable()
+export class FailureHookService implements OnModuleInit {
+  private readonly logger = new Logger(FailureHookService.name);
+
+  constructor(
+    @Inject(DATABASE_POOL) private readonly pool: Pool,
+    private readonly subscriber: SseSubscriberService,
+    private readonly api: N8nApiClient,
+    private readonly audit: AuditService,
+  ) {}
+
+  onModuleInit(): void {
+    this.subscriber.notifications.on('event', (payload: NotifyPayload) => {
+      if (payload.event_type !== 'workflow.failed') return;
+      // Fire-and-forget — log on failure but don't block the LISTEN loop.
+      void this.handle(payload).catch((err) =>
+        this.logger.warn(`failure hook failed for run ${payload.run_id}: ${(err as Error).message}`),
+      );
+    });
+  }
+
+  private async handle(payload: NotifyPayload): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query("SELECT set_config('app.tenant_id', $1, true)", [payload.tenant_id]);
+
+      const lock = await client.query(
+        `SELECT pg_try_advisory_xact_lock(hashtext($1)) AS acquired`,
+        [`proposal_trigger_failed:${payload.run_id}`],
+      );
+      if (!lock.rows[0]?.acquired) {
+        this.logger.debug(`another pod is handling failure for run ${payload.run_id}; skipping`);
+        await client.query('COMMIT');
+        return;
+      }
+
+      const runRes = await client.query(
+        `SELECT input FROM workflow_runs WHERE id = $1 LIMIT 1`,
+        [payload.run_id],
+      );
+      const providerExecutionId: string | undefined =
+        runRes.rows[0]?.input?.__provider?.providerExecutionId;
+      if (!providerExecutionId) {
+        await this.audit.log(
+          {
+            tenantId: payload.tenant_id,
+            actorType: 'system',
+            action: 'failure_hook.skipped_no_provider_id',
+            resourceType: 'workflow_run',
+            resourceId: payload.run_id,
+            metadata: { reason: 'workflow_runs.input.__provider.providerExecutionId missing' },
+          },
+          client,
+        );
+        await client.query('COMMIT');
+        return;
+      }
+
+      const execution = await this.api.getExecution(providerExecutionId);
+      const failedNodes = extractFailedNodes(execution?.data as N8nExecutionData | undefined);
+
+      if (failedNodes.length === 0) {
+        // Fallback: write a single trigger with no step_run_id so the agent
+        // worker still has a record to drain even if n8n's execution detail
+        // hasn't fully landed yet. The partial unique index is keyed on
+        // COALESCE(step_run_id, zero-uuid), so this is dedupable.
+        await this.insertTrigger(client, {
+          tenantId: payload.tenant_id,
+          workflowRunId: payload.run_id,
+          stepRunId: null,
+          errorFingerprint: fingerprint('unknown', execution?.status ?? 'failed'),
+          triggerContext: {
+            reason: 'no per-node error available from n8n execution detail',
+            n8n_execution_id: providerExecutionId,
+            last_successful_checkpoint: await this.fetchLastCheckpoint(client, payload.run_id),
+          },
+        });
+        await client.query('COMMIT');
+        return;
+      }
+
+      const lastCheckpoint = await this.fetchLastCheckpoint(client, payload.run_id);
+
+      for (const failed of failedNodes) {
+        const stepRunId = await this.findStepRunId(client, payload.run_id, failed.nodeName);
+        await this.insertTrigger(client, {
+          tenantId: payload.tenant_id,
+          workflowRunId: payload.run_id,
+          stepRunId,
+          errorFingerprint: fingerprint(failed.error.name, failed.error.message),
+          triggerContext: {
+            failing_step_key: failed.nodeName,
+            failing_step_run_id: stepRunId,
+            error: failed.error,
+            n8n_execution_id: providerExecutionId,
+            last_successful_checkpoint: lastCheckpoint,
+          },
+        });
+      }
+
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  private async insertTrigger(
+    client: PoolClient,
+    row: {
+      tenantId: string;
+      workflowRunId: string;
+      stepRunId: string | null;
+      errorFingerprint: string;
+      triggerContext: Record<string, unknown>;
+    },
+  ): Promise<void> {
+    // The partial unique index `idx_proposal_triggers_pending_dedupe`
+    // (migration 013) covers the (workflow_run_id, step_run_id,
+    // error_fingerprint) tuple for status='pending'. ON CONFLICT DO NOTHING
+    // makes the insert idempotent without throwing.
+    const res = await client.query(
+      `INSERT INTO proposal_triggers
+            (tenant_id, workflow_run_id, step_run_id, error_fingerprint, trigger_context, status)
+         VALUES ($1, $2, $3, $4, $5, 'pending')
+         ON CONFLICT (workflow_run_id, COALESCE(step_run_id, '00000000-0000-0000-0000-000000000000'::uuid), error_fingerprint)
+            WHERE status = 'pending'
+         DO NOTHING
+         RETURNING id`,
+      [
+        row.tenantId,
+        row.workflowRunId,
+        row.stepRunId,
+        row.errorFingerprint,
+        row.triggerContext,
+      ],
+    );
+
+    if (res.rows.length === 0) return; // already present
+
+    await this.audit.log(
+      {
+        tenantId: row.tenantId,
+        actorType: 'system',
+        action: 'workflow.run.failure_trigger_created',
+        resourceType: 'proposal_trigger',
+        resourceId: res.rows[0].id,
+        metadata: {
+          workflow_run_id: row.workflowRunId,
+          step_run_id: row.stepRunId,
+          error_fingerprint: row.errorFingerprint,
+        },
+      },
+      client,
+    );
+  }
+
+  private async findStepRunId(
+    client: PoolClient,
+    runId: string,
+    stepKey: string,
+  ): Promise<string | null> {
+    const res = await client.query(
+      `SELECT id FROM step_runs WHERE workflow_run_id = $1 AND step_key = $2 LIMIT 1`,
+      [runId, stepKey],
+    );
+    return res.rows[0]?.id ?? null;
+  }
+
+  private async fetchLastCheckpoint(
+    client: PoolClient,
+    runId: string,
+  ): Promise<unknown> {
+    const res = await client.query(
+      `SELECT event_data
+         FROM run_events
+        WHERE run_id = $1 AND event_type = 'step.completed'
+        ORDER BY sequence DESC
+        LIMIT 1`,
+      [runId],
+    );
+    return res.rows[0]?.event_data?.payload?.output ?? null;
+  }
+}
+
+interface FailedNode {
+  nodeName: string;
+  error: { name: string; message: string };
+}
+
+/**
+ * Walk n8n's `data.resultData.runData` shape. Each node maps to an array
+ * of execution attempts; we collect the latest attempt's error per node.
+ * Exported for unit testing.
+ */
+export function extractFailedNodes(data: N8nExecutionData | undefined): FailedNode[] {
+  if (!data?.resultData?.runData) return [];
+  const failed: FailedNode[] = [];
+  for (const [nodeName, attempts] of Object.entries(data.resultData.runData)) {
+    if (!Array.isArray(attempts) || attempts.length === 0) continue;
+    const last = attempts[attempts.length - 1];
+    if (last?.error?.message) {
+      failed.push({
+        nodeName,
+        error: {
+          name: last.error.name ?? 'NodeExecutionError',
+          message: last.error.message,
+        },
+      });
+    }
+  }
+  return failed;
+}
+
+function fingerprint(name: string, message: string): string {
+  return createHash('sha1').update(`${name}:${message}`).digest('hex').slice(0, 16);
+}

--- a/backend/src/runs/runs.controller.ts
+++ b/backend/src/runs/runs.controller.ts
@@ -4,12 +4,15 @@ import {
   Controller,
   ForbiddenException,
   Get,
+  Headers,
   HttpCode,
   HttpStatus,
+  MessageEvent,
   Param,
   ParseUUIDPipe,
   Post,
   Req,
+  Sse,
   UseGuards,
 } from '@nestjs/common';
 import {
@@ -17,13 +20,16 @@ import {
   ApiCreatedResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiProduces,
   ApiTags,
 } from '@nestjs/swagger';
+import { Observable } from 'rxjs';
 import { Request } from 'express';
 import { JwtAuthGuard } from '@/auth/jwt-auth.guard';
 import { RolesGuard } from '@/auth/roles.guard';
 import { Roles } from '@/auth/roles.decorator';
 import { RunsService, WorkflowRunWithRollup } from './runs.service';
+import { SseSubscriberService } from './sse-subscriber.service';
 import { CreateWorkflowRunDto, WorkflowRun } from './dto/workflow-run.dto';
 
 interface AuthedRequest extends Request {
@@ -47,7 +53,10 @@ const requireTenant = (req: AuthedRequest): { tenantId: string; actorId: string;
 @Controller({ path: 'workflow-runs', version: '1' })
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class RunsController {
-  constructor(private readonly runs: RunsService) {}
+  constructor(
+    private readonly runs: RunsService,
+    private readonly sse: SseSubscriberService,
+  ) {}
 
   @Post()
   @HttpCode(HttpStatus.CREATED)
@@ -77,6 +86,34 @@ export class RunsController {
   ): Promise<WorkflowRunWithRollup> {
     const { tenantId } = requireTenant(req);
     return this.runs.getWithRollup(id, tenantId);
+  }
+
+  @Sse(':id/events')
+  @ApiOperation({
+    summary: 'Subscribe to run events as Server-Sent Events',
+    description:
+      'Returns an SSE stream of `run_events` for the run, in monotonic sequence order. ' +
+      'Pass `Last-Event-ID` (an integer) on reconnect to resume after the last sequence ' +
+      'you received — the server backfills first, then switches to live LISTEN/NOTIFY ' +
+      'pushes. Heartbeat pings keep idle connections alive. RLS-scoped: the stream ' +
+      'returns nothing if the run is not visible to the caller tenant.',
+  })
+  @ApiProduces('text/event-stream')
+  async events(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Req() req: AuthedRequest,
+    @Headers('last-event-id') lastEventId?: string,
+  ): Promise<Observable<MessageEvent>> {
+    const { tenantId } = requireTenant(req);
+    // 404 before opening the long-lived stream; cleaner than streaming an
+    // empty Observable when the caller can't see this run.
+    await this.runs.getWithRollup(id, tenantId);
+    const parsedLastEventId = lastEventId ? Number(lastEventId) : undefined;
+    return this.sse.subscribe(
+      id,
+      tenantId,
+      Number.isFinite(parsedLastEventId) ? parsedLastEventId : undefined,
+    );
   }
 
   @Post(':id/cancel')

--- a/backend/src/runs/runs.controller.ts
+++ b/backend/src/runs/runs.controller.ts
@@ -1,0 +1,109 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  ForbiddenException,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Request } from 'express';
+import { JwtAuthGuard } from '@/auth/jwt-auth.guard';
+import { RolesGuard } from '@/auth/roles.guard';
+import { Roles } from '@/auth/roles.decorator';
+import { RunsService, WorkflowRunWithRollup } from './runs.service';
+import { CreateWorkflowRunDto, WorkflowRun } from './dto/workflow-run.dto';
+
+interface AuthedRequest extends Request {
+  user?: {
+    sub: string;
+    tenantId: string;
+    role?: string;
+    type: 'user' | 'service_account';
+  };
+}
+
+const requireTenant = (req: AuthedRequest): { tenantId: string; actorId: string; type: 'user' | 'service_account' } => {
+  if (!req.user?.sub || !req.user?.tenantId) {
+    throw new BadRequestException('authenticated context is missing');
+  }
+  return { tenantId: req.user.tenantId, actorId: req.user.sub, type: req.user.type };
+};
+
+@ApiTags('workflow-runs')
+@ApiBearerAuth()
+@Controller({ path: 'workflow-runs', version: '1' })
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class RunsController {
+  constructor(private readonly runs: RunsService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Start a workflow run',
+    description:
+      'Creates a workflow_runs row and triggers execution in n8n via the published artifact. ' +
+      'Returns the run with the provider executionId stashed in `input.__provider`. ' +
+      'The workflow_version must be in lifecycle_state=published.',
+  })
+  @ApiCreatedResponse({ description: 'The newly-created run with provider correlation stored.' })
+  async create(@Body() dto: CreateWorkflowRunDto, @Req() req: AuthedRequest): Promise<WorkflowRun> {
+    const { tenantId, actorId, type } = requireTenant(req);
+    return this.runs.create(dto, tenantId, type === 'user' ? { userId: actorId } : { serviceAccountId: actorId });
+  }
+
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Get a workflow run with step rollup',
+    description: 'Returns the run, its step_runs ordered by created_at, and a status histogram.',
+  })
+  @ApiOkResponse({ description: 'Run + steps + counts rollup.' })
+  async get(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Req() req: AuthedRequest,
+  ): Promise<WorkflowRunWithRollup> {
+    const { tenantId } = requireTenant(req);
+    return this.runs.getWithRollup(id, tenantId);
+  }
+
+  @Post(':id/cancel')
+  @HttpCode(HttpStatus.OK)
+  @Roles('admin')
+  @ApiOperation({
+    summary: 'Cancel a running workflow (admin only, cooperative)',
+    description:
+      'Flips workflow_runs.status to "cancelled" iff the run is still pending/running. ' +
+      'The n8n execution continues until its next injected `__pre_*` ping reads the new ' +
+      'status and routes to `__end_cancelled`. Returns `{ cancelled: true }` if state was ' +
+      'changed; `{ cancelled: false }` if the run was already terminal. ' +
+      'Note: n8n REST has no hard-stop in v1.79.0 (issue #14748); cancellation is ' +
+      'cooperative via the compiler-injected per-step ping.',
+  })
+  @ApiOkResponse({ description: '{ cancelled: boolean }' })
+  async cancel(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Req() req: AuthedRequest,
+  ): Promise<{ cancelled: boolean }> {
+    const { tenantId, actorId, type } = requireTenant(req);
+    if (type !== 'user') {
+      // Belt-and-braces — @Roles('admin') already requires `role`, which
+      // service-account tokens don't carry, so this path is unreachable.
+      // The explicit check keeps the intent legible.
+      throw new ForbiddenException('cancel is restricted to user tokens with role=admin');
+    }
+    return this.runs.cancel(id, tenantId, { userId: actorId });
+  }
+}

--- a/backend/src/runs/runs.module.ts
+++ b/backend/src/runs/runs.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { AuditModule } from '@/audit/audit.module';
+import { AuthModule } from '@/auth/auth.module';
+import { WorkflowsModule } from '@/workflows/workflows.module';
+import { RunsController } from './runs.controller';
+import { RunsService } from './runs.service';
+
+/**
+ * Phase 2.5a — workflow execution engine on top of the n8n adapter.
+ *
+ * Wires `POST/GET/cancel /v1/workflow-runs`. SSE event streaming and the
+ * failure → proposal_triggers hook land in later slices of the same PR.
+ *
+ * Imports WorkflowsModule for `N8nExecutionAdapter` so we share the single
+ * adapter instance with WorkflowsModule rather than provisioning a duplicate.
+ */
+@Module({
+  imports: [AuditModule, AuthModule, WorkflowsModule],
+  controllers: [RunsController],
+  providers: [RunsService],
+  exports: [RunsService],
+})
+export class RunsModule {}

--- a/backend/src/runs/runs.module.ts
+++ b/backend/src/runs/runs.module.ts
@@ -4,6 +4,7 @@ import { AuthModule } from '@/auth/auth.module';
 import { WorkflowsModule } from '@/workflows/workflows.module';
 import { RunsController } from './runs.controller';
 import { RunsService } from './runs.service';
+import { SseSubscriberService } from './sse-subscriber.service';
 
 /**
  * Phase 2.5a — workflow execution engine on top of the n8n adapter.
@@ -17,7 +18,7 @@ import { RunsService } from './runs.service';
 @Module({
   imports: [AuditModule, AuthModule, WorkflowsModule],
   controllers: [RunsController],
-  providers: [RunsService],
-  exports: [RunsService],
+  providers: [RunsService, SseSubscriberService],
+  exports: [RunsService, SseSubscriberService],
 })
 export class RunsModule {}

--- a/backend/src/runs/runs.module.ts
+++ b/backend/src/runs/runs.module.ts
@@ -5,6 +5,7 @@ import { WorkflowsModule } from '@/workflows/workflows.module';
 import { RunsController } from './runs.controller';
 import { RunsService } from './runs.service';
 import { SseSubscriberService } from './sse-subscriber.service';
+import { FailureHookService } from './failure-hook.service';
 
 /**
  * Phase 2.5a — workflow execution engine on top of the n8n adapter.
@@ -18,7 +19,7 @@ import { SseSubscriberService } from './sse-subscriber.service';
 @Module({
   imports: [AuditModule, AuthModule, WorkflowsModule],
   controllers: [RunsController],
-  providers: [RunsService, SseSubscriberService],
+  providers: [RunsService, SseSubscriberService, FailureHookService],
   exports: [RunsService, SseSubscriberService],
 })
 export class RunsModule {}

--- a/backend/src/runs/runs.service.spec.ts
+++ b/backend/src/runs/runs.service.spec.ts
@@ -64,15 +64,24 @@ describe('RunsService', () => {
   });
 
   describe('create', () => {
-    it('inserts, triggers, stashes provider id, audits, commits', async () => {
+    it('commits the INSERT before triggering n8n (so the row is visible to webhook callbacks)', async () => {
+      // Phase 1: insertPendingRun txn — BEGIN, set_config, version lookup, INSERT, COMMIT
       txnOpen(client);
       client.query
         .mockResolvedValueOnce({ rows: [{ id: VERSION }] }) // version lookup
         .mockResolvedValueOnce({ rows: [runRow()] }) // INSERT
+        .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+      // Phase 3: stashProviderAndAudit txn — BEGIN, set_config, UPDATE, COMMIT
+      txnOpen(client);
+      client.query
         .mockResolvedValueOnce({
-          rows: [runRow({ input: { __provider: { providerExecutionId: N8N_EXEC, n8nWorkflowId: N8N_WF } } })],
+          rows: [
+            runRow({ input: { __provider: { providerExecutionId: N8N_EXEC, n8nWorkflowId: N8N_WF } } }),
+          ],
         }) // UPDATE stash
         .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
       adapter.triggerExecution.mockResolvedValue({
         providerExecutionId: N8N_EXEC,
         n8nWorkflowId: N8N_WF,
@@ -84,15 +93,16 @@ describe('RunsService', () => {
         { userId: USER },
       );
 
-      expect(adapter.triggerExecution).toHaveBeenCalledWith({
-        workflowVersionId: VERSION,
-        tenantId: TENANT,
-        runId: RUN,
-        input: undefined,
-      });
+      // The trigger fires AFTER the insert txn closes — verify call order
+      const queryCalls = client.query.mock.calls.map((c) => c[0]);
+      const insertIdx = queryCalls.findIndex((q: string) => typeof q === 'string' && q.includes('INSERT INTO workflow_runs'));
+      const firstCommitIdx = queryCalls.indexOf('COMMIT');
+      expect(firstCommitIdx).toBeGreaterThan(insertIdx);
+      // adapter.triggerExecution is called between the two txns; assert it was called once
+      expect(adapter.triggerExecution).toHaveBeenCalledTimes(1);
+
       expect(audit.log).toHaveBeenCalledTimes(1);
-      const auditCall = audit.log.mock.calls[0][0];
-      expect(auditCall).toMatchObject({
+      expect(audit.log.mock.calls[0][0]).toMatchObject({
         action: 'workflow.run.started',
         tenantId: TENANT,
         actorType: 'user',
@@ -100,14 +110,10 @@ describe('RunsService', () => {
         resourceId: RUN,
       });
       expect(result.input.__provider.providerExecutionId).toBe(N8N_EXEC);
-      // ROLLBACK must not have run on the happy path
-      expect(client.query).toHaveBeenCalledWith('BEGIN');
-      expect(client.query).toHaveBeenCalledWith('COMMIT');
       expect(client.query).not.toHaveBeenCalledWith('ROLLBACK');
-      expect(client.release).toHaveBeenCalledTimes(1);
     });
 
-    it('rolls back when the version is not published or not in tenant', async () => {
+    it('rolls back the insert txn when the version is not published in this tenant', async () => {
       txnOpen(client);
       client.query
         .mockResolvedValueOnce({ rows: [] }) // version lookup empty
@@ -119,25 +125,38 @@ describe('RunsService', () => {
 
       expect(adapter.triggerExecution).not.toHaveBeenCalled();
       expect(client.query).toHaveBeenCalledWith('ROLLBACK');
-      expect(client.release).toHaveBeenCalled();
     });
 
-    it('rolls back if the adapter fails (no orphan run lands)', async () => {
+    it('marks the run failed when the adapter throws (run row stays, status flips to failed)', async () => {
+      // Phase 1: insert succeeds
       txnOpen(client);
       client.query
         .mockResolvedValueOnce({ rows: [{ id: VERSION }] })
         .mockResolvedValueOnce({ rows: [runRow()] })
-        .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+        .mockResolvedValueOnce({ rows: [] }); // COMMIT
       adapter.triggerExecution.mockRejectedValue(
         new N8nExecutionError('trigger_failed', 'boom'),
       );
+      // Phase 2 → markRunFailed txn — BEGIN, set_config, UPDATE, audit insert, COMMIT
+      txnOpen(client);
+      client.query
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE status=failed
+        .mockResolvedValueOnce({ rows: [] }); // COMMIT
 
       await expect(
         service.create({ workflowVersionId: VERSION }, TENANT, { userId: USER }),
       ).rejects.toThrow(N8nExecutionError);
 
-      expect(client.query).toHaveBeenCalledWith('ROLLBACK');
-      expect(audit.log).not.toHaveBeenCalled();
+      // markRunFailed runs in a follow-up txn and audits 'trigger_failed'
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'workflow.run.trigger_failed' }),
+        expect.anything(),
+      );
+      // 'workflow.run.started' audit is NEVER written when the trigger fails
+      expect(audit.log).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'workflow.run.started' }),
+        expect.anything(),
+      );
     });
   });
 

--- a/backend/src/runs/runs.service.spec.ts
+++ b/backend/src/runs/runs.service.spec.ts
@@ -1,0 +1,221 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { RunsService } from './runs.service';
+import { DATABASE_POOL } from '@/database/database.module';
+import { AuditService } from '@/audit/audit.service';
+import {
+  N8nExecutionAdapter,
+  N8nExecutionError,
+} from '@/workflows/adapters/n8n/n8n-execution.adapter';
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+const USER = '22222222-2222-2222-2222-222222222222';
+const VERSION = '33333333-3333-3333-3333-333333333333';
+const RUN = '44444444-4444-4444-4444-444444444444';
+const N8N_WF = 'n8n-wf-abc';
+const N8N_EXEC = 'n8n-exec-xyz';
+
+const txnOpen = (client: { query: jest.Mock }) => {
+  client.query
+    .mockResolvedValueOnce({ rows: [] }) // BEGIN
+    .mockResolvedValueOnce({ rows: [] }); // set_config
+};
+
+const runRow = (overrides: Record<string, unknown> = {}) => ({
+  id: RUN,
+  tenant_id: TENANT,
+  workflow_version_id: VERSION,
+  conversation_id: null,
+  task_graph_id: null,
+  execution_engine: 'n8n_queue',
+  status: 'pending',
+  input: {},
+  output: null,
+  error_details: null,
+  started_at: null,
+  completed_at: null,
+  created_at: new Date(),
+  updated_at: new Date(),
+  ...overrides,
+});
+
+describe('RunsService', () => {
+  let service: RunsService;
+  let client: { query: jest.Mock; release: jest.Mock };
+  let pool: { connect: jest.Mock };
+  let audit: { log: jest.Mock };
+  let adapter: { triggerExecution: jest.Mock };
+
+  beforeEach(async () => {
+    client = { query: jest.fn(), release: jest.fn() };
+    pool = { connect: jest.fn().mockResolvedValue(client) };
+    audit = { log: jest.fn().mockResolvedValue(undefined) };
+    adapter = { triggerExecution: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RunsService,
+        { provide: DATABASE_POOL, useValue: pool },
+        { provide: AuditService, useValue: audit },
+        { provide: N8nExecutionAdapter, useValue: adapter },
+      ],
+    }).compile();
+    service = module.get(RunsService);
+  });
+
+  describe('create', () => {
+    it('inserts, triggers, stashes provider id, audits, commits', async () => {
+      txnOpen(client);
+      client.query
+        .mockResolvedValueOnce({ rows: [{ id: VERSION }] }) // version lookup
+        .mockResolvedValueOnce({ rows: [runRow()] }) // INSERT
+        .mockResolvedValueOnce({
+          rows: [runRow({ input: { __provider: { providerExecutionId: N8N_EXEC, n8nWorkflowId: N8N_WF } } })],
+        }) // UPDATE stash
+        .mockResolvedValueOnce({ rows: [] }); // COMMIT
+      adapter.triggerExecution.mockResolvedValue({
+        providerExecutionId: N8N_EXEC,
+        n8nWorkflowId: N8N_WF,
+      });
+
+      const result = await service.create(
+        { workflowVersionId: VERSION },
+        TENANT,
+        { userId: USER },
+      );
+
+      expect(adapter.triggerExecution).toHaveBeenCalledWith({
+        workflowVersionId: VERSION,
+        tenantId: TENANT,
+        runId: RUN,
+        input: undefined,
+      });
+      expect(audit.log).toHaveBeenCalledTimes(1);
+      const auditCall = audit.log.mock.calls[0][0];
+      expect(auditCall).toMatchObject({
+        action: 'workflow.run.started',
+        tenantId: TENANT,
+        actorType: 'user',
+        actorId: USER,
+        resourceId: RUN,
+      });
+      expect(result.input.__provider.providerExecutionId).toBe(N8N_EXEC);
+      // ROLLBACK must not have run on the happy path
+      expect(client.query).toHaveBeenCalledWith('BEGIN');
+      expect(client.query).toHaveBeenCalledWith('COMMIT');
+      expect(client.query).not.toHaveBeenCalledWith('ROLLBACK');
+      expect(client.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('rolls back when the version is not published or not in tenant', async () => {
+      txnOpen(client);
+      client.query
+        .mockResolvedValueOnce({ rows: [] }) // version lookup empty
+        .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+      await expect(
+        service.create({ workflowVersionId: VERSION }, TENANT, { userId: USER }),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(adapter.triggerExecution).not.toHaveBeenCalled();
+      expect(client.query).toHaveBeenCalledWith('ROLLBACK');
+      expect(client.release).toHaveBeenCalled();
+    });
+
+    it('rolls back if the adapter fails (no orphan run lands)', async () => {
+      txnOpen(client);
+      client.query
+        .mockResolvedValueOnce({ rows: [{ id: VERSION }] })
+        .mockResolvedValueOnce({ rows: [runRow()] })
+        .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+      adapter.triggerExecution.mockRejectedValue(
+        new N8nExecutionError('trigger_failed', 'boom'),
+      );
+
+      await expect(
+        service.create({ workflowVersionId: VERSION }, TENANT, { userId: USER }),
+      ).rejects.toThrow(N8nExecutionError);
+
+      expect(client.query).toHaveBeenCalledWith('ROLLBACK');
+      expect(audit.log).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cancel', () => {
+    it('flips status when run is pending/running and audits', async () => {
+      txnOpen(client);
+      client.query
+        .mockResolvedValueOnce({
+          rows: [{ id: RUN, input: { __provider: { providerExecutionId: N8N_EXEC } } }],
+        }) // UPDATE
+        .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+      const result = await service.cancel(RUN, TENANT, { userId: USER });
+
+      expect(result).toEqual({ cancelled: true });
+      expect(audit.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'workflow.run.cancelled',
+          resourceId: RUN,
+          metadata: expect.objectContaining({ providerExecutionId: N8N_EXEC }),
+        }),
+        client,
+      );
+    });
+
+    it('returns { cancelled: false } when the run is already terminal', async () => {
+      txnOpen(client);
+      client.query
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE matched nothing
+        .mockResolvedValueOnce({ rows: [{ 1: 1 }] }) // existence check found it
+        .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+      const result = await service.cancel(RUN, TENANT, { userId: USER });
+
+      expect(result).toEqual({ cancelled: false });
+      expect(audit.log).not.toHaveBeenCalled();
+    });
+
+    it('404s when the run does not exist', async () => {
+      txnOpen(client);
+      client.query
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE matched nothing
+        .mockResolvedValueOnce({ rows: [] }) // existence check empty
+        .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+      await expect(service.cancel(RUN, TENANT, { userId: USER })).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getWithRollup', () => {
+    it('returns run + steps + counts', async () => {
+      txnOpen(client);
+      const now = new Date();
+      client.query
+        .mockResolvedValueOnce({ rows: [runRow({ status: 'running' })] })
+        .mockResolvedValueOnce({
+          rows: [
+            { id: 'step1', workflow_run_id: RUN, step_key: 'a', step_name: 'a', status: 'succeeded', created_at: now, updated_at: now },
+            { id: 'step2', workflow_run_id: RUN, step_key: 'b', step_name: 'b', status: 'running', created_at: now, updated_at: now },
+            { id: 'step3', workflow_run_id: RUN, step_key: 'c', step_name: 'c', status: 'failed', created_at: now, updated_at: now },
+          ],
+        })
+        .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+      const result = await service.getWithRollup(RUN, TENANT);
+
+      expect(result.run.status).toBe('running');
+      expect(result.steps).toHaveLength(3);
+      expect(result.counts).toEqual({ pending: 0, running: 1, succeeded: 1, failed: 1 });
+    });
+
+    it('404s when the run is not visible (RLS-scoped)', async () => {
+      txnOpen(client);
+      client.query
+        .mockResolvedValueOnce({ rows: [] }) // run lookup empty
+        .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+      await expect(service.getWithRollup(RUN, TENANT)).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/backend/src/runs/runs.service.ts
+++ b/backend/src/runs/runs.service.ts
@@ -32,21 +32,62 @@ export class RunsService {
 
   /**
    * Creates a workflow_runs row, asks the n8n adapter to start the execution,
-   * then stashes the provider's executionId on the run. We INSERT before the
-   * remote call so the run id is stable and the trigger payload can reference
-   * it; if the adapter call fails we ROLLBACK so no orphan run lands.
+   * then stashes the provider's executionId on the run.
+   *
+   * Ordering is load-bearing: the INSERT must be **committed** before we call
+   * the n8n adapter. n8n turns around and POSTs `__start_ping` back into our
+   * webhook controller almost immediately; those callbacks open a fresh DB
+   * connection and `SELECT FROM workflow_runs WHERE id = ...`, which can't
+   * see uncommitted rows across transactions and would drop the ping
+   * (`malformed payload` path).
+   *
+   * Failure mode: if the n8n trigger fails after the run has been
+   * committed, we mark the run `failed` in a follow-up txn rather than
+   * orphaning a pending row. The audit log breadcrumb survives even when
+   * the trigger blows up.
    */
   async create(
     dto: CreateWorkflowRunDto,
     tenantId: string,
     actor: RunActor,
   ): Promise<WorkflowRun> {
+    // Phase 1: validate + commit the run row so n8n callbacks can see it.
+    const insertedRun = await this.insertPendingRun(dto, tenantId);
+
+    // Phase 2: fire the trigger OUTSIDE the txn. If it fails, mark the run
+    // failed and rethrow.
+    let trigger;
+    try {
+      trigger = await this.executionAdapter.triggerExecution({
+        workflowVersionId: dto.workflowVersionId,
+        tenantId,
+        runId: insertedRun.id,
+        input: dto.input,
+      });
+    } catch (err) {
+      this.logger.warn(
+        `n8n trigger failed for run ${insertedRun.id}; marking failed: ${(err as Error).message}`,
+      );
+      await this.markRunFailed(insertedRun.id, tenantId, err as Error);
+      if (err instanceof N8nExecutionError) {
+        this.logger.warn(`run create failed: ${err.code} ${err.message}`);
+      }
+      throw err;
+    }
+
+    // Phase 3: stash the provider id + audit, in a small follow-up txn.
+    return this.stashProviderAndAudit(insertedRun.id, tenantId, dto, actor, trigger);
+  }
+
+  private async insertPendingRun(
+    dto: CreateWorkflowRunDto,
+    tenantId: string,
+  ): Promise<WorkflowRun> {
     const client = await this.pool.connect();
     try {
       await client.query('BEGIN');
       await client.query("SELECT set_config('app.tenant_id', $1, true)", [tenantId]);
 
-      // Confirm the version belongs to this tenant and is published.
       const versionRes = await client.query(
         `SELECT v.id
            FROM workflow_versions v
@@ -77,18 +118,29 @@ export class RunsService {
           dto.input ?? {},
         ],
       );
-      const run = mapRow(insertRes.rows[0]);
 
-      const trigger = await this.executionAdapter.triggerExecution({
-        workflowVersionId: dto.workflowVersionId,
-        tenantId,
-        runId: run.id,
-        input: dto.input,
-      });
+      await client.query('COMMIT');
+      return mapRow(insertRes.rows[0]);
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
 
-      // Stash the provider executionId so cancel/reconcile paths can find it.
-      // Using `input.__provider` rather than adding a column keeps this slice
-      // schema-light; an explicit column is a candidate for Phase 2.5b.
+  private async stashProviderAndAudit(
+    runId: string,
+    tenantId: string,
+    dto: CreateWorkflowRunDto,
+    actor: RunActor,
+    trigger: { providerExecutionId: string; n8nWorkflowId: string },
+  ): Promise<WorkflowRun> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query("SELECT set_config('app.tenant_id', $1, true)", [tenantId]);
+
       const stashed = await client.query(
         `UPDATE workflow_runs
             SET input = jsonb_set(coalesce(input, '{}'::jsonb), '{__provider}', $2::jsonb, true),
@@ -96,7 +148,7 @@ export class RunsService {
           WHERE id = $1
         RETURNING *`,
         [
-          run.id,
+          runId,
           JSON.stringify({
             providerExecutionId: trigger.providerExecutionId,
             n8nWorkflowId: trigger.n8nWorkflowId,
@@ -111,7 +163,7 @@ export class RunsService {
           actorType: actor.userId ? 'user' : 'service_account',
           action: 'workflow.run.started',
           resourceType: 'workflow_run',
-          resourceId: run.id,
+          resourceId: runId,
           metadata: {
             workflowVersionId: dto.workflowVersionId,
             providerExecutionId: trigger.providerExecutionId,
@@ -125,10 +177,42 @@ export class RunsService {
       return mapRow(stashed.rows[0]);
     } catch (err) {
       await client.query('ROLLBACK');
-      if (err instanceof N8nExecutionError) {
-        this.logger.warn(`run create failed: ${err.code} ${err.message}`);
-      }
       throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  private async markRunFailed(runId: string, tenantId: string, cause: Error): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query("SELECT set_config('app.tenant_id', $1, true)", [tenantId]);
+      await client.query(
+        `UPDATE workflow_runs
+            SET status = 'failed',
+                completed_at = COALESCE(completed_at, now()),
+                error_details = $2,
+                updated_at = now()
+          WHERE id = $1
+            AND status NOT IN ('cancelled', 'succeeded', 'failed')`,
+        [runId, { reason: 'trigger_failed', message: cause.message }],
+      );
+      await this.audit.log(
+        {
+          tenantId,
+          actorType: 'system',
+          action: 'workflow.run.trigger_failed',
+          resourceType: 'workflow_run',
+          resourceId: runId,
+          metadata: { message: cause.message, name: cause.name },
+        },
+        client,
+      );
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      this.logger.warn(`failed to mark run ${runId} as failed: ${(err as Error).message}`);
     } finally {
       client.release();
     }

--- a/backend/src/runs/runs.service.ts
+++ b/backend/src/runs/runs.service.ts
@@ -1,0 +1,264 @@
+import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Pool, PoolClient } from 'pg';
+import { DATABASE_POOL } from '@/database/database.module';
+import { AuditService } from '@/audit/audit.service';
+import {
+  N8nExecutionAdapter,
+  N8nExecutionError,
+} from '@/workflows/adapters/n8n/n8n-execution.adapter';
+import { CreateWorkflowRunDto, WorkflowRun } from './dto/workflow-run.dto';
+import { StepRun } from './dto/step-run.dto';
+
+export interface WorkflowRunWithRollup {
+  run: WorkflowRun;
+  steps: StepRun[];
+  counts: { pending: number; running: number; succeeded: number; failed: number };
+}
+
+export interface RunActor {
+  userId?: string;
+  serviceAccountId?: string;
+}
+
+@Injectable()
+export class RunsService {
+  private readonly logger = new Logger(RunsService.name);
+
+  constructor(
+    @Inject(DATABASE_POOL) private readonly pool: Pool,
+    private readonly audit: AuditService,
+    private readonly executionAdapter: N8nExecutionAdapter,
+  ) {}
+
+  /**
+   * Creates a workflow_runs row, asks the n8n adapter to start the execution,
+   * then stashes the provider's executionId on the run. We INSERT before the
+   * remote call so the run id is stable and the trigger payload can reference
+   * it; if the adapter call fails we ROLLBACK so no orphan run lands.
+   */
+  async create(
+    dto: CreateWorkflowRunDto,
+    tenantId: string,
+    actor: RunActor,
+  ): Promise<WorkflowRun> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query("SELECT set_config('app.tenant_id', $1, true)", [tenantId]);
+
+      // Confirm the version belongs to this tenant and is published.
+      const versionRes = await client.query(
+        `SELECT v.id
+           FROM workflow_versions v
+           JOIN workflow_defs d ON d.id = v.workflow_def_id
+          WHERE v.id = $1
+            AND d.tenant_id = $2
+            AND v.lifecycle_state = 'published'
+          LIMIT 1`,
+        [dto.workflowVersionId, tenantId],
+      );
+      if (versionRes.rows.length === 0) {
+        throw new NotFoundException(
+          `published workflow_version ${dto.workflowVersionId} not found for this tenant`,
+        );
+      }
+
+      const insertRes = await client.query(
+        `INSERT INTO workflow_runs
+            (tenant_id, workflow_version_id, conversation_id, task_graph_id, execution_engine, status, input)
+         VALUES ($1, $2, $3, $4, $5, 'pending', $6)
+         RETURNING *`,
+        [
+          tenantId,
+          dto.workflowVersionId,
+          dto.conversationId ?? null,
+          dto.taskGraphId ?? null,
+          dto.executionEngine ?? 'n8n_queue',
+          dto.input ?? {},
+        ],
+      );
+      const run = mapRow(insertRes.rows[0]);
+
+      const trigger = await this.executionAdapter.triggerExecution({
+        workflowVersionId: dto.workflowVersionId,
+        tenantId,
+        runId: run.id,
+        input: dto.input,
+      });
+
+      // Stash the provider executionId so cancel/reconcile paths can find it.
+      // Using `input.__provider` rather than adding a column keeps this slice
+      // schema-light; an explicit column is a candidate for Phase 2.5b.
+      const stashed = await client.query(
+        `UPDATE workflow_runs
+            SET input = jsonb_set(coalesce(input, '{}'::jsonb), '{__provider}', $2::jsonb, true),
+                updated_at = now()
+          WHERE id = $1
+        RETURNING *`,
+        [
+          run.id,
+          JSON.stringify({
+            providerExecutionId: trigger.providerExecutionId,
+            n8nWorkflowId: trigger.n8nWorkflowId,
+          }),
+        ],
+      );
+
+      await this.audit.log(
+        {
+          tenantId,
+          actorId: actor.userId ?? actor.serviceAccountId,
+          actorType: actor.userId ? 'user' : 'service_account',
+          action: 'workflow.run.started',
+          resourceType: 'workflow_run',
+          resourceId: run.id,
+          metadata: {
+            workflowVersionId: dto.workflowVersionId,
+            providerExecutionId: trigger.providerExecutionId,
+            n8nWorkflowId: trigger.n8nWorkflowId,
+          },
+        },
+        client,
+      );
+
+      await client.query('COMMIT');
+      return mapRow(stashed.rows[0]);
+    } catch (err) {
+      await client.query('ROLLBACK');
+      if (err instanceof N8nExecutionError) {
+        this.logger.warn(`run create failed: ${err.code} ${err.message}`);
+      }
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async getWithRollup(id: string, tenantId: string): Promise<WorkflowRunWithRollup> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query("SELECT set_config('app.tenant_id', $1, true)", [tenantId]);
+
+      const runRes = await client.query(
+        `SELECT * FROM workflow_runs WHERE id = $1 LIMIT 1`,
+        [id],
+      );
+      if (runRes.rows.length === 0) {
+        throw new NotFoundException(`workflow_run ${id} not found`);
+      }
+      const run = mapRow(runRes.rows[0]);
+
+      const stepsRes = await client.query(
+        `SELECT * FROM step_runs WHERE workflow_run_id = $1 ORDER BY created_at ASC`,
+        [id],
+      );
+      const steps = stepsRes.rows.map(mapStepRow);
+
+      const counts = { pending: 0, running: 0, succeeded: 0, failed: 0 };
+      for (const s of steps) {
+        if (s.status in counts) (counts as Record<string, number>)[s.status]++;
+      }
+
+      await client.query('COMMIT');
+      return { run, steps, counts };
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Cooperative cancellation. Flips status to 'cancelled' iff the run is still
+   * in pending/running — protects against a `workflow.completed` arriving
+   * after a user cancel from being silently undone. The actual halt happens
+   * inside n8n: the next `__pre_*` ping reads the new status and routes to
+   * the synthetic `__end_cancelled` node.
+   */
+  async cancel(id: string, tenantId: string, actor: RunActor): Promise<{ cancelled: boolean }> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query("SELECT set_config('app.tenant_id', $1, true)", [tenantId]);
+
+      const upd = await client.query(
+        `UPDATE workflow_runs
+            SET status = 'cancelled', updated_at = now()
+          WHERE id = $1 AND status IN ('pending', 'running')
+        RETURNING id, input`,
+        [id],
+      );
+
+      if (upd.rows.length === 0) {
+        // Either not found or already terminal. Distinguish for the API:
+        const exists = await client.query(`SELECT 1 FROM workflow_runs WHERE id = $1`, [id]);
+        await client.query('COMMIT');
+        if (exists.rows.length === 0) {
+          throw new NotFoundException(`workflow_run ${id} not found`);
+        }
+        return { cancelled: false };
+      }
+
+      const providerExecutionId =
+        upd.rows[0].input?.__provider?.providerExecutionId ?? null;
+
+      await this.audit.log(
+        {
+          tenantId,
+          actorId: actor.userId ?? actor.serviceAccountId,
+          actorType: actor.userId ? 'user' : 'service_account',
+          action: 'workflow.run.cancelled',
+          resourceType: 'workflow_run',
+          resourceId: id,
+          metadata: { providerExecutionId },
+        },
+        client,
+      );
+
+      await client.query('COMMIT');
+      return { cancelled: true };
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+}
+
+const mapRow = (row: Record<string, any>): WorkflowRun => ({
+  id: row.id,
+  tenantId: row.tenant_id,
+  workflowVersionId: row.workflow_version_id,
+  conversationId: row.conversation_id ?? undefined,
+  taskGraphId: row.task_graph_id ?? undefined,
+  executionEngine: row.execution_engine,
+  status: row.status,
+  input: row.input ?? {},
+  output: row.output ?? undefined,
+  errorDetails: row.error_details ?? undefined,
+  startedAt: row.started_at ?? undefined,
+  completedAt: row.completed_at ?? undefined,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+});
+
+const mapStepRow = (row: Record<string, any>): StepRun => ({
+  id: row.id,
+  workflowRunId: row.workflow_run_id,
+  stepKey: row.step_key,
+  stepName: row.step_name,
+  status: row.status,
+  input: row.input ?? undefined,
+  output: row.output ?? undefined,
+  errorDetails: row.error_details ?? undefined,
+  startedAt: row.started_at ?? undefined,
+  completedAt: row.completed_at ?? undefined,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+});
+
+// PoolClient is used implicitly via audit.log signature; keep import live.
+export type { PoolClient };

--- a/backend/src/runs/sse-subscriber.service.spec.ts
+++ b/backend/src/runs/sse-subscriber.service.spec.ts
@@ -1,0 +1,243 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import type { MessageEvent } from '@nestjs/common';
+import { firstValueFrom, take, toArray, lastValueFrom, timer } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
+import { SseSubscriberService, NotifyPayload } from './sse-subscriber.service';
+import { DATABASE_POOL } from '@/database/database.module';
+
+const RUN = '11111111-1111-1111-1111-111111111111';
+const TENANT = '22222222-2222-2222-2222-222222222222';
+
+interface MockClient {
+  query: jest.Mock;
+  release: jest.Mock;
+}
+
+interface MockPool {
+  connect: jest.Mock;
+  client: MockClient;
+}
+
+const makeMockPool = (
+  rowsByCall: Array<{ rows: any[] }> = [],
+): MockPool => {
+  const queue = [...rowsByCall];
+  const client: MockClient = {
+    query: jest.fn().mockImplementation((sql: string) => {
+      if (sql.startsWith('BEGIN') || sql.startsWith('SELECT set_config') || sql.startsWith('COMMIT') || sql.startsWith('ROLLBACK')) {
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve(queue.shift() ?? { rows: [] });
+    }),
+    release: jest.fn(),
+  };
+  return {
+    connect: jest.fn().mockResolvedValue(client),
+    client,
+  };
+};
+
+const buildService = async (
+  pool: MockPool,
+  heartbeatMs = 1_000_000, // disable in tests
+): Promise<SseSubscriberService> => {
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      SseSubscriberService,
+      { provide: DATABASE_POOL, useValue: pool },
+      {
+        provide: ConfigService,
+        useValue: {
+          get: (k: string) => (k === 'SSE_HEARTBEAT_MS' ? String(heartbeatMs) : ''),
+        },
+      },
+    ],
+  }).compile();
+  return module.get(SseSubscriberService);
+};
+
+const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+describe('SseSubscriberService', () => {
+  describe('subscribe + backfill', () => {
+    it('backfills events with sequence > lastEventId in order', async () => {
+      const pool = makeMockPool([
+        {
+          rows: [
+            { id: 'e2', sequence: 2, event_type: 'step.started', event_data: { a: 1 }, step_run_id: null, occurred_at: '2026-05-18T10:00:01Z' },
+            { id: 'e3', sequence: 3, event_type: 'step.completed', event_data: { a: 2 }, step_run_id: null, occurred_at: '2026-05-18T10:00:02Z' },
+          ],
+        },
+      ]);
+      const svc = await buildService(pool);
+      const obs$ = svc.subscribe(RUN, TENANT, 1);
+      const events = await firstValueFrom(obs$.pipe(take(2), toArray()));
+      expect(events.map((e) => e.id)).toEqual(['2', '3']);
+      expect(events.map((e) => e.type)).toEqual(['step.started', 'step.completed']);
+    });
+
+    it('starts from sequence 0 when no lastEventId is provided', async () => {
+      const pool = makeMockPool([
+        { rows: [{ id: 'e1', sequence: 1, event_type: 'workflow.started', event_data: {}, step_run_id: null, occurred_at: '2026-05-18T10:00:00Z' }] },
+      ]);
+      const svc = await buildService(pool);
+      const obs$ = svc.subscribe(RUN, TENANT);
+      const ev = await firstValueFrom(obs$.pipe(take(1)));
+      expect(ev.id).toBe('1');
+      // Verify the SQL parameters used afterSequence=0
+      const backfillCall = pool.client.query.mock.calls.find(
+        ([sql]) => typeof sql === 'string' && sql.includes('FROM run_events'),
+      );
+      expect(backfillCall?.[1]).toEqual([RUN, 0]);
+    });
+  });
+
+  describe('fan-out + de-dup', () => {
+    it('de-duplicates a live notification whose sequence was already backfilled', async () => {
+      // Backfill returns seq=1,2. Then a live NOTIFY at seq=2 arrives. Only
+      // the original 2 events should be emitted.
+      const pool = makeMockPool([
+        {
+          rows: [
+            { id: 'e1', sequence: 1, event_type: 'workflow.started', event_data: {}, step_run_id: null, occurred_at: 't1' },
+            { id: 'e2', sequence: 2, event_type: 'step.started', event_data: {}, step_run_id: null, occurred_at: 't2' },
+          ],
+        },
+        // Second pool.connect (fetchEventRow for the live notification)
+        {
+          rows: [
+            { sequence: 2, event_type: 'step.started', event_data: {}, occurred_at: 't2' },
+          ],
+        },
+      ]);
+      const svc = await buildService(pool);
+      const obs$ = svc.subscribe(RUN, TENANT, 0);
+      const collected: MessageEvent[] = [];
+      const sub = obs$.subscribe((e) => collected.push(e));
+
+      // Wait for backfill to flush
+      await flush();
+      await flush();
+
+      // Fire a live notification at sequence=2 — should be dropped.
+      const payload: NotifyPayload = {
+        run_id: RUN,
+        tenant_id: TENANT,
+        sequence: 2,
+        event_type: 'step.started',
+        step_run_id: null,
+        event_id: 'e2',
+      };
+      (svc as unknown as { onNotification: (m: { channel: string; payload?: string }) => void }).onNotification({
+        channel: 'run_events',
+        payload: JSON.stringify(payload),
+      });
+      await flush();
+      sub.unsubscribe();
+
+      expect(collected.map((e) => e.id)).toEqual(['1', '2']);
+    });
+
+    it('emits live notifications whose sequence is greater than the last sent', async () => {
+      const pool = makeMockPool([
+        { rows: [] }, // empty backfill
+        {
+          rows: [
+            { sequence: 5, event_type: 'workflow.completed', event_data: { ok: true }, occurred_at: 't5' },
+          ],
+        },
+      ]);
+      const svc = await buildService(pool);
+      const obs$ = svc.subscribe(RUN, TENANT, 0);
+      const collected: MessageEvent[] = [];
+      const sub = obs$.subscribe((e) => collected.push(e));
+      await flush();
+
+      (svc as unknown as { onNotification: (m: { channel: string; payload?: string }) => void }).onNotification({
+        channel: 'run_events',
+        payload: JSON.stringify({
+          run_id: RUN,
+          tenant_id: TENANT,
+          sequence: 5,
+          event_type: 'workflow.completed',
+          step_run_id: null,
+          event_id: 'e5',
+        }),
+      });
+      await flush();
+      sub.unsubscribe();
+
+      expect(collected).toHaveLength(1);
+      expect(collected[0].id).toBe('5');
+      expect(collected[0].type).toBe('workflow.completed');
+    });
+  });
+
+  describe('heartbeat', () => {
+    it('emits heartbeat ping events on the configured interval', async () => {
+      const pool = makeMockPool([{ rows: [] }]);
+      const svc = await buildService(pool, 5); // 5ms heartbeat
+      const obs$ = svc.subscribe(RUN, TENANT, 0);
+      const collected: MessageEvent[] = [];
+      const sub = obs$.subscribe((e) => collected.push(e));
+
+      await lastValueFrom(timer(50).pipe(mergeMap(() => [0])));
+      sub.unsubscribe();
+
+      const pings = collected.filter((e) => e.type === 'ping');
+      // Exact ping count depends on event-loop scheduling under load;
+      // assert the stream is alive and a heartbeat actually fired.
+      expect(pings.length).toBeGreaterThanOrEqual(1);
+      expect(pings[0]).toEqual({ type: 'ping', data: '' });
+    });
+  });
+
+  describe('FailureHookService bridge', () => {
+    it('emits "event" on the in-process EventEmitter for every NOTIFY', async () => {
+      const pool = makeMockPool();
+      const svc = await buildService(pool);
+      const received: NotifyPayload[] = [];
+      svc.notifications.on('event', (p: NotifyPayload) => received.push(p));
+
+      const payload: NotifyPayload = {
+        run_id: RUN,
+        tenant_id: TENANT,
+        sequence: 7,
+        event_type: 'workflow.failed',
+        step_run_id: null,
+        event_id: 'e7',
+      };
+      (svc as unknown as { onNotification: (m: { channel: string; payload?: string }) => void }).onNotification({
+        channel: 'run_events',
+        payload: JSON.stringify(payload),
+      });
+      expect(received).toEqual([payload]);
+    });
+
+    it('ignores notifications on the wrong channel', async () => {
+      const pool = makeMockPool();
+      const svc = await buildService(pool);
+      const received: NotifyPayload[] = [];
+      svc.notifications.on('event', (p: NotifyPayload) => received.push(p));
+      (svc as unknown as { onNotification: (m: { channel: string; payload?: string }) => void }).onNotification({
+        channel: 'other_channel',
+        payload: JSON.stringify({ run_id: RUN }),
+      });
+      expect(received).toEqual([]);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('removes the subject from the map when the subscriber unsubscribes', async () => {
+      const pool = makeMockPool([{ rows: [] }]);
+      const svc = await buildService(pool);
+      const obs$ = svc.subscribe(RUN, TENANT);
+      const sub = obs$.subscribe();
+      const map = (svc as unknown as { subscribers: Map<string, Set<unknown>> }).subscribers;
+      expect(map.get(RUN)?.size).toBe(1);
+      sub.unsubscribe();
+      expect(map.has(RUN)).toBe(false);
+    });
+  });
+});

--- a/backend/src/runs/sse-subscriber.service.spec.ts
+++ b/backend/src/runs/sse-subscriber.service.spec.ts
@@ -185,6 +185,70 @@ describe('SseSubscriberService', () => {
       expect(collected.map((e) => e.id)).toEqual(['1', '2', '3', '4', '5', '10']);
     });
 
+    it('serializes per-run fan-out so two back-to-back notifications emit in NOTIFY arrival order even when the second fetch resolves first (regression: Copilot review)', async () => {
+      // Pre-fix race: onNotification fired fanOut without awaiting; two
+      // concurrent fetches could resolve out of order, the higher seq would
+      // win the watermark, the lower seq would be silently dropped.
+      // Fix: per-run promise chain serializes fanOut for the same run.
+      let resolveSlow: (rows: any) => void = () => {};
+      const slowPromise = new Promise<any>((res) => {
+        resolveSlow = res;
+      });
+
+      const client: MockClient = {
+        query: jest.fn().mockImplementation((sql: string, params?: any[]) => {
+          if (sql.startsWith('BEGIN') || sql.startsWith('SELECT set_config') || sql.startsWith('COMMIT') || sql.startsWith('ROLLBACK')) {
+            return Promise.resolve({ rows: [] });
+          }
+          if (sql.includes('FROM run_events WHERE id')) {
+            // Slow fetch for the seq=5 event id
+            if (params?.[0] === 'evt-5') return slowPromise.then((r) => ({ rows: r }));
+            // Fast fetch for the seq=6 event id
+            if (params?.[0] === 'evt-6') return Promise.resolve({
+              rows: [{ sequence: 6, event_type: 'step.completed', event_data: { v: 6 }, occurred_at: 't6' }],
+            });
+          }
+          return Promise.resolve({ rows: [] });
+        }),
+        release: jest.fn(),
+      };
+      const pool: MockPool = { connect: jest.fn().mockResolvedValue(client), client };
+      const svc = await buildService(pool);
+
+      // Live path only — backfill returns empty (the mock has no rows
+      // configured for the backfill SELECT against `WHERE sequence > $2`).
+      const obs$ = svc.subscribe(RUN, TENANT, 0);
+      const collected: MessageEvent[] = [];
+      const sub = obs$.subscribe((e) => collected.push(e));
+      // Let backfill txn drain so `backfilling` flips to false.
+      await flush(); await flush(); await flush();
+
+      // Fire seq=5 FIRST (slow fetch), then seq=6 (fast fetch).
+      const fire = (seq: number, eid: string) =>
+        (svc as unknown as { onNotification: (m: any) => void }).onNotification({
+          channel: 'run_events',
+          payload: JSON.stringify({
+            run_id: RUN, tenant_id: TENANT, sequence: seq,
+            event_type: 'step.started', step_run_id: null, event_id: eid,
+          }),
+        });
+      fire(5, 'evt-5');
+      fire(6, 'evt-6');
+
+      // seq=6's fetch could resolve immediately; let microtasks run.
+      await flush(); await flush();
+      // With the per-run chain, seq=6's fanOut hasn't even started — it's
+      // chained behind seq=5's slow fetch. Resolve seq=5 now.
+      resolveSlow([{ sequence: 5, event_type: 'step.started', event_data: { v: 5 }, occurred_at: 't5' }]);
+      await flush(); await flush(); await flush();
+
+      sub.unsubscribe();
+
+      // Must arrive in NOTIFY arrival order: seq=5 first, then seq=6.
+      // Without the chain, this would be ['6'] only.
+      expect(collected.map((e) => e.id)).toEqual(['5', '6']);
+    });
+
     it('emits live notifications whose sequence is greater than the last sent', async () => {
       const pool = makeMockPool([
         { rows: [] }, // empty backfill

--- a/backend/src/runs/sse-subscriber.service.spec.ts
+++ b/backend/src/runs/sse-subscriber.service.spec.ts
@@ -139,6 +139,52 @@ describe('SseSubscriberService', () => {
       expect(collected.map((e) => e.id)).toEqual(['1', '2']);
     });
 
+    it('preserves backfill order when a live event arrives mid-backfill (regression: Copilot review)', async () => {
+      // Backfill returns seq=1..5. While backfill is in flight, a live
+      // NOTIFY at seq=10 arrives. Without buffering, the live event would
+      // advance the watermark and cause backfill rows 2..5 to be silently
+      // dropped by the `row.sequence <= lastSentSequence` check.
+      const pool = makeMockPool([
+        {
+          rows: [
+            { id: 'e1', sequence: 1, event_type: 'step.started', event_data: {}, step_run_id: null, occurred_at: 't1' },
+            { id: 'e2', sequence: 2, event_type: 'step.completed', event_data: {}, step_run_id: null, occurred_at: 't2' },
+            { id: 'e3', sequence: 3, event_type: 'step.started', event_data: {}, step_run_id: null, occurred_at: 't3' },
+            { id: 'e4', sequence: 4, event_type: 'step.completed', event_data: {}, step_run_id: null, occurred_at: 't4' },
+            { id: 'e5', sequence: 5, event_type: 'step.started', event_data: {}, step_run_id: null, occurred_at: 't5' },
+          ],
+        },
+        // fetchEventRow response for the live NOTIFY (seq=10)
+        { rows: [{ sequence: 10, event_type: 'workflow.completed', event_data: {}, occurred_at: 't10' }] },
+      ]);
+      const svc = await buildService(pool);
+      const obs$ = svc.subscribe(RUN, TENANT, 0);
+      const collected: MessageEvent[] = [];
+      const sub = obs$.subscribe((e) => collected.push(e));
+
+      // Fire the live NOTIFY immediately — before backfill's await chain
+      // resolves. The subscriber should buffer it as pendingLive.
+      (svc as unknown as { onNotification: (m: { channel: string; payload?: string }) => void }).onNotification({
+        channel: 'run_events',
+        payload: JSON.stringify({
+          run_id: RUN,
+          tenant_id: TENANT,
+          sequence: 10,
+          event_type: 'workflow.completed',
+          step_run_id: null,
+          event_id: 'e10',
+        }),
+      });
+
+      await flush();
+      await flush();
+      await flush();
+      sub.unsubscribe();
+
+      // All 5 backfill rows must arrive in order, THEN the buffered live event.
+      expect(collected.map((e) => e.id)).toEqual(['1', '2', '3', '4', '5', '10']);
+    });
+
     it('emits live notifications whose sequence is greater than the last sent', async () => {
       const pool = makeMockPool([
         { rows: [] }, // empty backfill

--- a/backend/src/runs/sse-subscriber.service.ts
+++ b/backend/src/runs/sse-subscriber.service.ts
@@ -1,0 +1,308 @@
+import {
+  Inject,
+  Injectable,
+  Logger,
+  MessageEvent,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Client, Pool } from 'pg';
+import { EventEmitter } from 'events';
+import { Observable, Subject, interval, merge } from 'rxjs';
+import { finalize, map, takeUntil } from 'rxjs/operators';
+import { DATABASE_POOL } from '@/database/database.module';
+
+const CHANNEL = 'run_events';
+
+export interface NotifyPayload {
+  run_id: string;
+  tenant_id: string;
+  sequence: number;
+  event_type: string;
+  step_run_id: string | null;
+  event_id: string;
+}
+
+interface RunSubscription {
+  subject: Subject<MessageEvent>;
+  tenantId: string;
+  lastSentSequence: number; // monotonically increasing; de-dups against backfill/notify race
+}
+
+/**
+ * Owns a single long-lived Postgres LISTEN client (NOT from the pool —
+ * pool clients are recycled every `idleTimeoutMillis`, which would silently
+ * drop LISTEN subscriptions). Fans out notifications to per-run RxJS
+ * subjects consumed by:
+ *   - `RunsController.events` SSE endpoint
+ *   - `FailureHookService` (next slice) via the `notifications` EventEmitter
+ *
+ * Reconnect strategy is bounded exponential backoff (1s → 30s). On reconnect
+ * we re-issue `LISTEN run_events`; existing SSE consumers transparently
+ * resume because their `EventSource` clients reconnect with `Last-Event-ID`
+ * which triggers a fresh backfill via `subscribe()`.
+ */
+@Injectable()
+export class SseSubscriberService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(SseSubscriberService.name);
+  private readonly subscribers = new Map<string, Set<RunSubscription>>();
+  /** In-process bus used by FailureHookService so we don't open a 2nd LISTEN client. */
+  readonly notifications = new EventEmitter();
+  private client: Client | null = null;
+  private readonly destroy$ = new Subject<void>();
+  private reconnectAttempts = 0;
+  private shuttingDown = false;
+  private readonly heartbeatMs: number;
+  private readonly connectionString: string;
+  private readonly ssl: false | { rejectUnauthorized: boolean };
+
+  constructor(
+    @Inject(DATABASE_POOL) private readonly pool: Pool,
+    @Inject(ConfigService) config: ConfigService,
+  ) {
+    this.heartbeatMs = Number(config.get<string>('SSE_HEARTBEAT_MS') ?? '15000');
+    this.connectionString = config.get<string>('DATABASE_URL') ?? '';
+    this.ssl =
+      config.get<string>('DATABASE_SSL') === 'true'
+        ? {
+            rejectUnauthorized:
+              config.get<string>('DATABASE_SSL_REJECT_UNAUTHORIZED', 'true') !== 'false',
+          }
+        : false;
+    // Bump the EE cap — one listener per failure-hook + future debugging.
+    this.notifications.setMaxListeners(50);
+  }
+
+  async onModuleInit(): Promise<void> {
+    await this.connect();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    this.shuttingDown = true;
+    this.destroy$.next();
+    this.destroy$.complete();
+    if (this.client) {
+      try {
+        await this.client.end();
+      } catch (err) {
+        this.logger.warn(`shutdown error closing LISTEN client: ${(err as Error).message}`);
+      }
+    }
+    for (const subs of this.subscribers.values()) {
+      for (const s of subs) s.subject.complete();
+    }
+    this.subscribers.clear();
+  }
+
+  /**
+   * Open the dedicated LISTEN connection. On any subsequent error we drop
+   * the client and schedule a reconnect with exponential backoff; SSE
+   * consumers stay registered and resume when the channel reopens.
+   */
+  private async connect(): Promise<void> {
+    if (this.shuttingDown) return;
+    const client = new Client({ connectionString: this.connectionString, ssl: this.ssl });
+    client.on('notification', (msg) => this.onNotification(msg));
+    client.on('error', (err) => {
+      this.logger.warn(`LISTEN client error: ${err.message}`);
+      void this.scheduleReconnect();
+    });
+    client.on('end', () => {
+      if (!this.shuttingDown) {
+        this.logger.warn('LISTEN client ended unexpectedly; scheduling reconnect');
+        void this.scheduleReconnect();
+      }
+    });
+    try {
+      await client.connect();
+      await client.query(`LISTEN ${CHANNEL}`);
+      this.client = client;
+      this.reconnectAttempts = 0;
+      this.logger.log(`SSE subscriber listening on channel "${CHANNEL}"`);
+    } catch (err) {
+      this.logger.warn(`LISTEN connect failed: ${(err as Error).message}`);
+      try { await client.end(); } catch { /* ignore */ }
+      this.client = null;
+      void this.scheduleReconnect();
+    }
+  }
+
+  private async scheduleReconnect(): Promise<void> {
+    if (this.shuttingDown) return;
+    this.client = null;
+    this.reconnectAttempts++;
+    const delayMs = Math.min(30000, 1000 * 2 ** Math.min(this.reconnectAttempts - 1, 5));
+    this.logger.log(`reconnecting LISTEN client in ${delayMs}ms (attempt ${this.reconnectAttempts})`);
+    setTimeout(() => void this.connect(), delayMs);
+  }
+
+  /**
+   * Handle one Postgres NOTIFY message. Re-emits on the in-process bus for
+   * non-SSE consumers (FailureHookService) and pushes to any per-run SSE
+   * subjects. RLS is honored by re-fetching the full row under the run's
+   * tenant scope when the SSE pipeline needs `event_data`.
+   */
+  private onNotification(msg: { channel: string; payload?: string }): void {
+    if (msg.channel !== CHANNEL || !msg.payload) return;
+    let payload: NotifyPayload;
+    try {
+      payload = JSON.parse(msg.payload);
+    } catch (err) {
+      this.logger.warn(`malformed NOTIFY payload: ${(err as Error).message}`);
+      return;
+    }
+    this.notifications.emit('event', payload);
+
+    const subs = this.subscribers.get(payload.run_id);
+    if (!subs || subs.size === 0) return;
+    void this.fanOut(payload, subs);
+  }
+
+  private async fanOut(payload: NotifyPayload, subs: Set<RunSubscription>): Promise<void> {
+    try {
+      const row = await this.fetchEventRow(payload.event_id, payload.tenant_id);
+      if (!row) return;
+      const event: MessageEvent = {
+        id: String(row.sequence),
+        type: row.event_type,
+        data: JSON.stringify({
+          run_id: payload.run_id,
+          step_run_id: payload.step_run_id,
+          event_data: row.event_data,
+          occurred_at: row.occurred_at,
+        }),
+      };
+      for (const s of subs) {
+        if (row.sequence <= s.lastSentSequence) continue;
+        s.subject.next(event);
+        s.lastSentSequence = row.sequence;
+      }
+    } catch (err) {
+      this.logger.warn(`fanOut failed for run ${payload.run_id}: ${(err as Error).message}`);
+    }
+  }
+
+  private async fetchEventRow(
+    eventId: string,
+    tenantId: string,
+  ): Promise<{
+    sequence: number;
+    event_type: string;
+    event_data: unknown;
+    occurred_at: Date;
+  } | null> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query("SELECT set_config('app.tenant_id', $1, true)", [tenantId]);
+      const res = await client.query(
+        `SELECT sequence, event_type, event_data, occurred_at
+           FROM run_events WHERE id = $1 LIMIT 1`,
+        [eventId],
+      );
+      await client.query('COMMIT');
+      return res.rows[0] ?? null;
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Returns an Observable that emits MessageEvents for `runId`, backfilled
+   * starting after `lastEventId` (inclusive of all newer rows), then live
+   * from NOTIFY. Heartbeats every `SSE_HEARTBEAT_MS` keep reverse-proxies
+   * from closing the connection.
+   */
+  subscribe(
+    runId: string,
+    tenantId: string,
+    lastEventId?: number,
+  ): Observable<MessageEvent> {
+    const subject = new Subject<MessageEvent>();
+    const startingSequence = Number.isFinite(lastEventId) ? Number(lastEventId) : 0;
+    const sub: RunSubscription = {
+      subject,
+      tenantId,
+      lastSentSequence: startingSequence,
+    };
+
+    // Register BEFORE backfill so a notification arriving in the window
+    // between backfill and live subscribe lands in the subject; the
+    // de-dup on `lastSentSequence` makes the overlap idempotent.
+    let set = this.subscribers.get(runId);
+    if (!set) {
+      set = new Set();
+      this.subscribers.set(runId, set);
+    }
+    set.add(sub);
+
+    // Kick off backfill asynchronously so the caller gets the Observable
+    // synchronously and downstream `.pipe(...)` can hook in.
+    void this.backfill(runId, tenantId, startingSequence, sub);
+
+    // Heartbeat keeps proxies happy. We use `type: 'ping'` to make the
+    // record explicit (clients can ignore unknown types).
+    const heartbeat$ = interval(this.heartbeatMs).pipe(
+      map<number, MessageEvent>(() => ({ type: 'ping', data: '' })),
+    );
+
+    return merge(subject.asObservable(), heartbeat$).pipe(
+      takeUntil(this.destroy$),
+      finalize(() => {
+        const current = this.subscribers.get(runId);
+        if (current) {
+          current.delete(sub);
+          if (current.size === 0) this.subscribers.delete(runId);
+        }
+        subject.complete();
+      }),
+    );
+  }
+
+  private async backfill(
+    runId: string,
+    tenantId: string,
+    afterSequence: number,
+    sub: RunSubscription,
+  ): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query("SELECT set_config('app.tenant_id', $1, true)", [tenantId]);
+      const res = await client.query(
+        `SELECT id, sequence, event_type, event_data, step_run_id, occurred_at
+           FROM run_events
+          WHERE run_id = $1 AND sequence > $2
+          ORDER BY sequence ASC`,
+        [runId, afterSequence],
+      );
+      await client.query('COMMIT');
+
+      for (const row of res.rows) {
+        if (row.sequence <= sub.lastSentSequence) continue;
+        sub.subject.next({
+          id: String(row.sequence),
+          type: row.event_type,
+          data: JSON.stringify({
+            run_id: runId,
+            step_run_id: row.step_run_id,
+            event_data: row.event_data,
+            occurred_at: row.occurred_at,
+          }),
+        });
+        sub.lastSentSequence = row.sequence;
+      }
+    } catch (err) {
+      await client.query('ROLLBACK');
+      this.logger.warn(`backfill failed for run ${runId}: ${(err as Error).message}`);
+      sub.subject.error(err);
+    } finally {
+      client.release();
+    }
+  }
+}
+

--- a/backend/src/runs/sse-subscriber.service.ts
+++ b/backend/src/runs/sse-subscriber.service.ts
@@ -28,6 +28,16 @@ interface RunSubscription {
   subject: Subject<MessageEvent>;
   tenantId: string;
   lastSentSequence: number; // monotonically increasing; de-dups against backfill/notify race
+  /**
+   * True while initial backfill is still running. Live notifications received
+   * during this window are queued into `pendingLive` instead of fanning out
+   * directly — otherwise a live event with sequence N can advance
+   * `lastSentSequence` past backfill rows with sequence < N, causing those
+   * backfill rows to be silently dropped by the watermark check.
+   */
+  backfilling: boolean;
+  /** Buffer for live NOTIFY-derived events that arrive during backfill. */
+  pendingLive: MessageEvent[];
 }
 
 /**
@@ -53,6 +63,7 @@ export class SseSubscriberService implements OnModuleInit, OnModuleDestroy {
   private readonly destroy$ = new Subject<void>();
   private reconnectAttempts = 0;
   private shuttingDown = false;
+  private reconnectTimer: NodeJS.Timeout | null = null;
   private readonly heartbeatMs: number;
   private readonly connectionString: string;
   private readonly ssl: false | { rejectUnauthorized: boolean };
@@ -82,6 +93,12 @@ export class SseSubscriberService implements OnModuleInit, OnModuleDestroy {
     this.shuttingDown = true;
     this.destroy$.next();
     this.destroy$.complete();
+    // Cancel any pending reconnect so we don't open a fresh Client during
+    // shutdown (Gemini review PR #65).
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
     if (this.client) {
       try {
         await this.client.end();
@@ -134,7 +151,11 @@ export class SseSubscriberService implements OnModuleInit, OnModuleDestroy {
     this.reconnectAttempts++;
     const delayMs = Math.min(30000, 1000 * 2 ** Math.min(this.reconnectAttempts - 1, 5));
     this.logger.log(`reconnecting LISTEN client in ${delayMs}ms (attempt ${this.reconnectAttempts})`);
-    setTimeout(() => void this.connect(), delayMs);
+    // Store the handle so onModuleDestroy can clear it cleanly.
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.connect();
+    }, delayMs);
   }
 
   /**
@@ -174,6 +195,14 @@ export class SseSubscriberService implements OnModuleInit, OnModuleDestroy {
         }),
       };
       for (const s of subs) {
+        if (s.backfilling) {
+          // Queue live events arriving during backfill. Without this,
+          // advancing `lastSentSequence` here would cause backfill rows
+          // with smaller sequences to be skipped silently by the watermark
+          // check in `backfill()` — Copilot review PR #65.
+          s.pendingLive.push(event);
+          continue;
+        }
         if (row.sequence <= s.lastSentSequence) continue;
         s.subject.next(event);
         s.lastSentSequence = row.sequence;
@@ -228,6 +257,8 @@ export class SseSubscriberService implements OnModuleInit, OnModuleDestroy {
       subject,
       tenantId,
       lastSentSequence: startingSequence,
+      backfilling: true,
+      pendingLive: [],
     };
 
     // Register BEFORE backfill so a notification arriving in the window
@@ -296,9 +327,26 @@ export class SseSubscriberService implements OnModuleInit, OnModuleDestroy {
         });
         sub.lastSentSequence = row.sequence;
       }
+
+      // Phase 2.5a — flush events that were queued while backfill ran.
+      // Any pending live event with sequence <= lastSentSequence (already
+      // covered by backfill) is discarded; the rest replay in arrival order.
+      // The flag flip + flush must happen synchronously so a notification
+      // arriving here doesn't slip into pendingLive after we've already
+      // started draining.
+      sub.backfilling = false;
+      const queued = sub.pendingLive;
+      sub.pendingLive = [];
+      for (const ev of queued) {
+        const seq = Number(ev.id);
+        if (!Number.isFinite(seq) || seq <= sub.lastSentSequence) continue;
+        sub.subject.next(ev);
+        sub.lastSentSequence = seq;
+      }
     } catch (err) {
       await client.query('ROLLBACK');
       this.logger.warn(`backfill failed for run ${runId}: ${(err as Error).message}`);
+      sub.backfilling = false;
       sub.subject.error(err);
     } finally {
       client.release();

--- a/backend/src/runs/sse-subscriber.service.ts
+++ b/backend/src/runs/sse-subscriber.service.ts
@@ -59,6 +59,15 @@ export class SseSubscriberService implements OnModuleInit, OnModuleDestroy {
   private readonly subscribers = new Map<string, Set<RunSubscription>>();
   /** In-process bus used by FailureHookService so we don't open a 2nd LISTEN client. */
   readonly notifications = new EventEmitter();
+  /**
+   * Per-run promise chain. Two NOTIFYs arriving back-to-back run their
+   * `fetchEventRow` round-trips in parallel; if the higher-sequence fetch
+   * resolves first it advances `lastSentSequence` and the lower-sequence
+   * event is silently dropped by the watermark check. Chaining each
+   * fan-out off the previous settle keeps row order at the cost of one
+   * round-trip's latency per notification per run (Copilot review PR #65).
+   */
+  private readonly fanoutTails = new Map<string, Promise<void>>();
   private client: Client | null = null;
   private readonly destroy$ = new Subject<void>();
   private reconnectAttempts = 0;
@@ -177,7 +186,23 @@ export class SseSubscriberService implements OnModuleInit, OnModuleDestroy {
 
     const subs = this.subscribers.get(payload.run_id);
     if (!subs || subs.size === 0) return;
-    void this.fanOut(payload, subs);
+
+    // Serialize per-run fan-out: chain the new task off the previous tail
+    // so two NOTIFYs arriving back-to-back can't interleave their
+    // `fetchEventRow` and silently drop the lower-sequence event. The
+    // chain is keyed per-run so a slow fetch on one run doesn't stall
+    // other runs.
+    const runId = payload.run_id;
+    const prev = this.fanoutTails.get(runId) ?? Promise.resolve();
+    const next = prev.then(() => this.fanOut(payload, subs));
+    this.fanoutTails.set(runId, next);
+    void next.finally(() => {
+      // Drop the tail when it's the current one — otherwise newer
+      // notifications have already extended the chain.
+      if (this.fanoutTails.get(runId) === next) {
+        this.fanoutTails.delete(runId);
+      }
+    });
   }
 
   private async fanOut(payload: NotifyPayload, subs: Set<RunSubscription>): Promise<void> {

--- a/backend/src/workflows/adapters/n8n/n8n-api.client.ts
+++ b/backend/src/workflows/adapters/n8n/n8n-api.client.ts
@@ -94,6 +94,51 @@ export class N8nApiClient {
     }
   }
 
+  /**
+   * Trigger a manual-trigger workflow via the public REST API. The body is
+   * passed straight through to n8n as the manual trigger's input payload —
+   * downstream nodes read `$json.runId` / `$json.tenantId` / `$json.input` to
+   * propagate run correlation. n8n's response shape for this endpoint is not
+   * formally documented and varies across versions; the field is best-effort.
+   * If `executionId` is missing the caller should poll via `listExecutions`.
+   *
+   * Caveat: community reports intermittent failures where 2xx is returned but
+   * the manual trigger doesn't actually fire — see
+   * https://community.n8n.io/t/executing-a-workflow-via-api-call-without-webhook-or-cli-command/212895
+   */
+  async runWorkflow(
+    id: string,
+    body: { runId: string; tenantId: string; input?: unknown },
+    timeoutMs?: number,
+  ): Promise<{ executionId?: string; data?: unknown }> {
+    return this.request<{ executionId?: string; data?: unknown }>(
+      'POST',
+      `/workflows/${id}/run`,
+      body,
+      timeoutMs,
+    );
+  }
+
+  /**
+   * List executions for a given n8n workflow id, newest first. Used as the
+   * fallback when `runWorkflow` returns 2xx without `executionId`.
+   */
+  async listExecutions(params: {
+    workflowId: string;
+    limit?: number;
+  }): Promise<N8nExecutionResponse[]> {
+    const qs = new URLSearchParams({
+      workflowId: params.workflowId,
+      limit: String(params.limit ?? 1),
+    });
+    const res = await this.request<{ data?: N8nExecutionResponse[] } | N8nExecutionResponse[]>(
+      'GET',
+      `/executions?${qs.toString()}`,
+    );
+    if (Array.isArray(res)) return res;
+    return res.data ?? [];
+  }
+
   private async request<T>(
     method: string,
     path: string,

--- a/backend/src/workflows/adapters/n8n/n8n-compiler.spec.ts
+++ b/backend/src/workflows/adapters/n8n/n8n-compiler.spec.ts
@@ -74,8 +74,41 @@ describe('compileToN8n', () => {
 
     expect(artifact.workflow.connections.__trigger.main[0][0].node).toBe('__start_ping');
     expect(artifact.workflow.connections.__start_ping.main[0][0].node).toBe('__pre_b_http');
-    expect(artifact.workflow.connections.__pre_b_http.main[0][0].node).toBe('b_http');
+    // Phase 2.5a: __pre_<id> now feeds the cancel-check IF rather than the
+    // canonical node directly. The IF's false branch (output 1) is the step.
+    expect(artifact.workflow.connections.__pre_b_http.main[0][0].node).toBe('__cancel_check_b_http');
+    expect(artifact.workflow.connections.__cancel_check_b_http.main[0][0].node).toBe('__end_cancelled');
+    expect(artifact.workflow.connections.__cancel_check_b_http.main[1][0].node).toBe('b_http');
     expect(artifact.workflow.connections.b_http.main[0][0].node).toBe('__post_b_http');
+  });
+
+  it('injects one cancel-check IF per step + a single shared __end_cancelled sink', () => {
+    const artifact = compileToN8n(compileOk(linear), OPTS);
+    const names = artifact.workflow.nodes.map((n) => n.name);
+    expect(names).toContain('__cancel_check_b_http');
+    expect(names).toContain('__cancel_check_c_set');
+    // Single shared sink, not one per step
+    expect(names.filter((n) => n === '__end_cancelled')).toHaveLength(1);
+
+    // IF is an n8n IF v2 node
+    const check = artifact.workflow.nodes.find((n) => n.name === '__cancel_check_b_http')!;
+    expect(check.type).toBe('n8n-nodes-base.if');
+    const conds = (check.parameters as any).conditions;
+    expect(conds.conditions[0].leftValue).toContain('$json.cancelled');
+    expect(conds.conditions[0].operator.type).toBe('boolean');
+
+    // Every step's cancel-check sends true → __end_cancelled and false → step
+    for (const step of ['b_http', 'c_set']) {
+      const conn = artifact.workflow.connections[`__cancel_check_${step}`];
+      expect(conn.main[0][0].node).toBe('__end_cancelled');
+      expect(conn.main[1][0].node).toBe(step);
+    }
+
+    // __end_cancelled is an HTTP Request posting `workflow.cancelled` to the
+    // webhook controller (reuses pingNode).
+    const sink = artifact.workflow.nodes.find((n) => n.name === '__end_cancelled')!;
+    expect(sink.type).toBe('n8n-nodes-base.httpRequest');
+    expect((sink.parameters as any).jsonBody).toContain('"event":"workflow.cancelled"');
   });
 
   it('emits a separate errorWorkflow with errorTrigger + failure ping', () => {

--- a/backend/src/workflows/adapters/n8n/n8n-compiler.ts
+++ b/backend/src/workflows/adapters/n8n/n8n-compiler.ts
@@ -477,7 +477,11 @@ function cancelCheckNode(name: string, x: number, y: number): N8nNode {
         conditions: [
           {
             id: 'cancel-check',
-            leftValue: '={{ $json.cancelled === true }}',
+            // Pass the raw boolean through; the operator below does the
+            // truthiness check. Doing `=== true` here AND running the
+            // boolean.true operator double-evaluates and risks coercion
+            // surprises across n8n IF v2 minor versions (Copilot review PR #65).
+            leftValue: '={{ $json.cancelled }}',
             rightValue: '',
             operator: { type: 'boolean', operation: 'true', singleValue: true },
           },

--- a/backend/src/workflows/adapters/n8n/n8n-compiler.ts
+++ b/backend/src/workflows/adapters/n8n/n8n-compiler.ts
@@ -53,6 +53,9 @@ const POST_DX = 80;
 const TRIGGER_NAME = '__trigger';
 const START_PING = '__start_ping';
 const END_PING = '__end_ping';
+const END_CANCELLED = '__end_cancelled';
+const CANCEL_CHECK_PREFIX = '__cancel_check_';
+const CHECK_DX = -40; // sits between __pre_<id> (PRE_DX = -80) and the canonical node (0)
 
 /**
  * Canonical output port → n8n output index for multi-output node types.
@@ -141,6 +144,7 @@ export function compileToN8n(
     const baseX = (idx + 2) * X_OFFSET;
     const preName = `__pre_${canonicalId}`;
     const postName = `__post_${canonicalId}`;
+    const checkName = `${CANCEL_CHECK_PREFIX}${canonicalId}`;
     const node = compiled.nodes[canonicalId];
 
     nodes.push(
@@ -150,8 +154,18 @@ export function compileToN8n(
         triggerSource: 'manual',
       }),
     );
+
+    // Cooperative cancel: the pre-ping returns { cancelled: boolean } from
+    // the webhook handler (a single SELECT against workflow_runs.status).
+    // The IF routes the true branch to the shared __end_cancelled sink and
+    // the false branch to the actual canonical node. n8n IF v2 output
+    // index 0 = true, 1 = false (matches PORT_INDEX.branch).
+    nodes.push(cancelCheckNode(checkName, baseX + CHECK_DX, 0));
+    addConnection(connections, preName, checkName);
+    addConnection(connections, checkName, END_CANCELLED, 'main', 0);
+    addConnection(connections, checkName, canonicalId, 'main', 1);
+
     nodes.push(canonicalToN8nNode(node, baseX, 0, opts));
-    addConnection(connections, preName, canonicalId);
 
     if (hasPostPing(node.type)) {
       nodes.push(
@@ -164,6 +178,16 @@ export function compileToN8n(
       addConnection(connections, canonicalId, postName);
     }
   }
+
+  // Single sink for cooperative cancel. Emits one workflow.cancelled event
+  // per run (only the first IF that resolves to true reaches this sink;
+  // subsequent steps never run because their pre-pings are not invoked).
+  nodes.push(
+    pingNode(END_CANCELLED, (functionalIds.length + 2) * X_OFFSET, 120, opts, {
+      event: 'workflow.cancelled',
+      triggerSource: 'manual',
+    }),
+  );
 
   // Drive forward connections from canonical edges (port-aware).
   for (const edge of compiled.edges) {
@@ -425,6 +449,40 @@ function pingNode(
       options: {
         retry: { retries: 2 },
         response: { response: { neverError: true } },
+      },
+    },
+  };
+}
+
+/**
+ * Cooperative-cancel IF node. Reads `$json.cancelled` from the preceding
+ * pre-ping's response (the webhook controller sets it from
+ * `workflow_runs.status='cancelled'`). Output 0 = true → __end_cancelled;
+ * output 1 = false → the canonical step.
+ *
+ * Uses the n8n IF v2 condition schema. The single boolean condition with
+ * `operator.operation='true'` and `singleValue=true` evaluates the leftValue
+ * for truthiness. The `id` is fixed (load-bearing for determinism: omitted
+ * IDs make n8n generate random ones).
+ */
+function cancelCheckNode(name: string, x: number, y: number): N8nNode {
+  return {
+    name,
+    type: IF_NODE,
+    typeVersion: IF_VERSION,
+    position: [x, y],
+    parameters: {
+      conditions: {
+        options: { caseSensitive: true, leftValue: '', typeValidation: 'loose' },
+        conditions: [
+          {
+            id: 'cancel-check',
+            leftValue: '={{ $json.cancelled === true }}',
+            rightValue: '',
+            operator: { type: 'boolean', operation: 'true', singleValue: true },
+          },
+        ],
+        combinator: 'and',
       },
     },
   };

--- a/backend/src/workflows/adapters/n8n/n8n-execution.adapter.spec.ts
+++ b/backend/src/workflows/adapters/n8n/n8n-execution.adapter.spec.ts
@@ -1,0 +1,118 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import {
+  N8nExecutionAdapter,
+  N8nExecutionError,
+} from './n8n-execution.adapter';
+import { N8nApiClient, N8nApiError } from './n8n-api.client';
+import { DATABASE_POOL } from '@/database/database.module';
+
+const VERSION = '11111111-1111-1111-1111-111111111111';
+const TENANT = '22222222-2222-2222-2222-222222222222';
+const RUN = '33333333-3333-3333-3333-333333333333';
+const N8N_WF = 'n8n-wf-abc';
+const N8N_EXEC = 'n8n-exec-xyz';
+
+const buildAdapter = async (overrides?: {
+  artifactArtifact?: unknown;
+  apiOverrides?: Partial<jest.Mocked<N8nApiClient>>;
+  config?: Record<string, string>;
+}): Promise<{
+  adapter: N8nExecutionAdapter;
+  api: jest.Mocked<N8nApiClient>;
+  poolQuery: jest.Mock;
+}> => {
+  const poolQuery = jest.fn().mockResolvedValue({
+    rows:
+      overrides?.artifactArtifact === null
+        ? []
+        : [{ artifact: overrides?.artifactArtifact ?? { n8nWorkflowId: N8N_WF } }],
+  });
+  const api: jest.Mocked<N8nApiClient> = {
+    runWorkflow: jest.fn(),
+    listExecutions: jest.fn(),
+  } as unknown as jest.Mocked<N8nApiClient>;
+  Object.assign(api, overrides?.apiOverrides ?? {});
+
+  const cfg = overrides?.config ?? { N8N_TRIGGER_LIST_FALLBACK_DELAY_MS: '0' };
+
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      N8nExecutionAdapter,
+      { provide: DATABASE_POOL, useValue: { query: poolQuery } },
+      { provide: N8nApiClient, useValue: api },
+      {
+        provide: ConfigService,
+        useValue: { get: (k: string) => cfg[k] },
+      },
+    ],
+  }).compile();
+  return { adapter: module.get(N8nExecutionAdapter), api, poolQuery };
+};
+
+describe('N8nExecutionAdapter', () => {
+  it('returns providerExecutionId from runWorkflow response', async () => {
+    const { adapter, api } = await buildAdapter();
+    (api.runWorkflow as jest.Mock).mockResolvedValue({ executionId: N8N_EXEC });
+
+    const result = await adapter.triggerExecution({
+      workflowVersionId: VERSION,
+      tenantId: TENANT,
+      runId: RUN,
+      input: { foo: 1 },
+    });
+
+    expect(api.runWorkflow).toHaveBeenCalledWith(
+      N8N_WF,
+      { runId: RUN, tenantId: TENANT, input: { foo: 1 } },
+      expect.any(Number),
+    );
+    expect(result).toEqual({ providerExecutionId: N8N_EXEC, n8nWorkflowId: N8N_WF });
+    // listExecutions fallback must not fire when runWorkflow returned an id
+    expect(api.listExecutions).not.toHaveBeenCalled();
+  });
+
+  it('falls back to listExecutions when runWorkflow returns no executionId', async () => {
+    const { adapter, api } = await buildAdapter();
+    (api.runWorkflow as jest.Mock).mockResolvedValue({});
+    (api.listExecutions as jest.Mock).mockResolvedValue([{ id: N8N_EXEC }]);
+
+    const result = await adapter.triggerExecution({
+      workflowVersionId: VERSION,
+      tenantId: TENANT,
+      runId: RUN,
+    });
+
+    expect(api.listExecutions).toHaveBeenCalledWith({ workflowId: N8N_WF, limit: 1 });
+    expect(result.providerExecutionId).toBe(N8N_EXEC);
+  });
+
+  it('throws artifact_not_synced when no n8n workflow id is cached', async () => {
+    const { adapter } = await buildAdapter({ artifactArtifact: null });
+
+    await expect(
+      adapter.triggerExecution({ workflowVersionId: VERSION, tenantId: TENANT, runId: RUN }),
+    ).rejects.toMatchObject({ code: 'artifact_not_synced' });
+  });
+
+  it('wraps adapter HTTP errors with N8nExecutionError', async () => {
+    const { adapter, api } = await buildAdapter();
+    (api.runWorkflow as jest.Mock).mockRejectedValue(
+      new N8nApiError(500, 'boom', 'n8n POST /workflows/x/run -> 500'),
+    );
+
+    await expect(
+      adapter.triggerExecution({ workflowVersionId: VERSION, tenantId: TENANT, runId: RUN }),
+    ).rejects.toMatchObject({ code: 'trigger_failed' });
+  });
+
+  it('throws execution_id_missing when both runWorkflow and listExecutions are empty', async () => {
+    const { adapter, api } = await buildAdapter();
+    (api.runWorkflow as jest.Mock).mockResolvedValue({});
+    (api.listExecutions as jest.Mock).mockResolvedValue([]);
+
+    await expect(
+      adapter.triggerExecution({ workflowVersionId: VERSION, tenantId: TENANT, runId: RUN }),
+    ).rejects.toMatchObject({ code: 'execution_id_missing' });
+  });
+});

--- a/backend/src/workflows/adapters/n8n/n8n-execution.adapter.ts
+++ b/backend/src/workflows/adapters/n8n/n8n-execution.adapter.ts
@@ -1,0 +1,125 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Pool } from 'pg';
+import { DATABASE_POOL } from '@/database/database.module';
+import { N8nApiClient, N8nApiError } from './n8n-api.client';
+import type { N8nCompiledArtifact } from './types';
+
+export interface TriggerExecutionParams {
+  workflowVersionId: string;
+  tenantId: string;
+  runId: string;
+  input?: Record<string, unknown>;
+}
+
+export interface TriggerExecutionResult {
+  providerExecutionId: string;
+  n8nWorkflowId: string;
+}
+
+export class N8nExecutionError extends Error {
+  constructor(public readonly code: string, message: string) {
+    super(message);
+    this.name = 'N8nExecutionError';
+  }
+}
+
+/**
+ * Starts an n8n execution for a published workflow_version. Looks up the
+ * cached `workflow_adapter_artifacts.artifact.n8nWorkflowId` written by
+ * `N8nSyncService.syncPublishedVersion`, then calls
+ * `POST /workflows/:id/run`. The trigger body is consumed by the manual
+ * trigger node injected at compile time (`n8n-compiler.ts`).
+ *
+ * Phase 2.5a does NOT implement adapter-side cancel: n8n's
+ * `POST /executions/:id/stop` returns 404 in v1.79.0
+ * (https://github.com/n8n-io/n8n/issues/14748). Cancellation is cooperative
+ * via the compiler's per-step `__pre_*` ping which reads
+ * `workflow_runs.status` and short-circuits when cancelled.
+ */
+@Injectable()
+export class N8nExecutionAdapter {
+  private readonly logger = new Logger(N8nExecutionAdapter.name);
+  private readonly triggerTimeoutMs: number;
+  private readonly listFallbackDelayMs: number;
+
+  constructor(
+    @Inject(DATABASE_POOL) private readonly pool: Pool,
+    @Inject(ConfigService) config: ConfigService,
+    private readonly api: N8nApiClient,
+  ) {
+    this.triggerTimeoutMs = Number(config.get<string>('N8N_TRIGGER_TIMEOUT_MS') ?? '10000');
+    this.listFallbackDelayMs = Number(
+      config.get<string>('N8N_TRIGGER_LIST_FALLBACK_DELAY_MS') ?? '500',
+    );
+  }
+
+  async triggerExecution(params: TriggerExecutionParams): Promise<TriggerExecutionResult> {
+    const { workflowVersionId, tenantId, runId, input } = params;
+
+    const n8nWorkflowId = await this.lookupN8nWorkflowId(workflowVersionId);
+    if (!n8nWorkflowId) {
+      throw new N8nExecutionError(
+        'artifact_not_synced',
+        `no workflow_adapter_artifacts row for workflow_version ${workflowVersionId} (workflow must be published first)`,
+      );
+    }
+
+    let response: { executionId?: string };
+    try {
+      response = await this.api.runWorkflow(
+        n8nWorkflowId,
+        { runId, tenantId, input: input ?? {} },
+        this.triggerTimeoutMs,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new N8nExecutionError('trigger_failed', `n8n /workflows/${n8nWorkflowId}/run failed: ${msg}`);
+    }
+
+    if (response.executionId) {
+      return { providerExecutionId: response.executionId, n8nWorkflowId };
+    }
+
+    // Fallback: n8n returned 2xx but no executionId. Give n8n a beat to record
+    // the execution, then ask for the newest one for this workflow id. The
+    // run we just started should be the most recent.
+    this.logger.warn(
+      `n8n /workflows/${n8nWorkflowId}/run returned no executionId; falling back to listExecutions`,
+    );
+    await delay(this.listFallbackDelayMs);
+
+    let fallbackExecutions: { id: string }[] = [];
+    try {
+      fallbackExecutions = await this.api.listExecutions({ workflowId: n8nWorkflowId, limit: 1 });
+    } catch (err) {
+      if (!(err instanceof N8nApiError)) throw err;
+      throw new N8nExecutionError(
+        'execution_id_lookup_failed',
+        `n8n run accepted but executionId fallback failed: ${err.message}`,
+      );
+    }
+
+    const newest = fallbackExecutions[0];
+    if (!newest?.id) {
+      throw new N8nExecutionError(
+        'execution_id_missing',
+        `n8n run accepted but no executionId could be resolved for workflow ${n8nWorkflowId}`,
+      );
+    }
+    return { providerExecutionId: newest.id, n8nWorkflowId };
+  }
+
+  private async lookupN8nWorkflowId(workflowVersionId: string): Promise<string | null> {
+    const res = await this.pool.query(
+      `SELECT artifact FROM workflow_adapter_artifacts
+       WHERE workflow_version_id = $1 AND adapter_type = 'n8n' LIMIT 1`,
+      [workflowVersionId],
+    );
+    if (res.rows.length === 0) return null;
+    const artifact = res.rows[0].artifact as N8nCompiledArtifact;
+    return artifact.n8nWorkflowId ?? null;
+  }
+}
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));

--- a/backend/src/workflows/adapters/n8n/n8n-webhook.controller.spec.ts
+++ b/backend/src/workflows/adapters/n8n/n8n-webhook.controller.spec.ts
@@ -206,4 +206,75 @@ describe('N8nWebhookController.receive', () => {
       controller.receive(SECRET, { event: 'step.started', timestamp: freshTimestamp() } as any),
     ).rejects.toThrow(UnauthorizedException);
   });
+
+  describe('cooperative cancel response (Phase 2.5a)', () => {
+    function makeControllerWithCancelState(isCancelled: boolean) {
+      const queries: Array<{ sql: string; params: any[] }> = [];
+      const client = {
+        query: async (sql: string, params: any[] = []) => {
+          queries.push({ sql, params });
+          if (sql.includes("event_data->>'event_id'")) return { rows: [] };
+          if (sql.includes('INSERT INTO step_runs')) return { rows: [{ id: 'sr' }] };
+          // The cancel-state probe lands as: SELECT 1 FROM workflow_runs WHERE id=$1 AND status='cancelled'
+          if (sql.includes("status = 'cancelled'")) {
+            return isCancelled ? { rows: [{ '?column?': 1 }] } : { rows: [] };
+          }
+          return { rows: [] };
+        },
+        release: () => {},
+      };
+      const pool = { connect: async () => client } as any;
+      const audit: AuditService = { log: async () => {} } as any;
+      const api: N8nApiClient = { getExecution: async () => null } as any;
+      return {
+        controller: new N8nWebhookController(pool, mockConfig(), api, audit),
+        queries,
+      };
+    }
+
+    it('returns cancelled=true when workflow_runs.status is cancelled', async () => {
+      const { controller, queries } = makeControllerWithCancelState(true);
+      const r = await controller.receive(SECRET, event({ event: 'step.started', stepKey: 'a' }));
+      expect(r).toEqual({ ok: true, cancelled: true });
+      // Probe ran inside the txn
+      expect(queries.some((q) => q.sql.includes("status = 'cancelled'"))).toBe(true);
+    });
+
+    it('returns cancelled=false on the happy path', async () => {
+      const { controller } = makeControllerWithCancelState(false);
+      const r = await controller.receive(SECRET, event({ event: 'step.started', stepKey: 'a' }));
+      expect(r).toEqual({ ok: true, cancelled: false });
+    });
+
+    it('still surfaces cancelled flag when the event is deduped', async () => {
+      // Build a controller whose dedup probe finds the event AND status is cancelled
+      const queries: Array<{ sql: string; params: any[] }> = [];
+      const client = {
+        query: async (sql: string, params: any[] = []) => {
+          queries.push({ sql, params });
+          if (sql.includes("event_data->>'event_id'")) return { rows: [{ '?column?': 1 }] };
+          if (sql.includes("status = 'cancelled'")) return { rows: [{ '?column?': 1 }] };
+          return { rows: [] };
+        },
+        release: () => {},
+      };
+      const pool = { connect: async () => client } as any;
+      const audit: AuditService = { log: async () => {} } as any;
+      const api: N8nApiClient = { getExecution: async () => null } as any;
+      const c = new N8nWebhookController(pool, mockConfig(), api, audit);
+
+      const r = await c.receive(SECRET, event({ event: 'step.started', stepKey: 'a' }));
+      expect(r).toEqual({ ok: true, deduped: true, cancelled: true });
+    });
+
+    it('accepts the new workflow.cancelled event type', async () => {
+      const { controller, queries } = makeControllerWithCancelState(true);
+      const r = await controller.receive(SECRET, event({ event: 'workflow.cancelled' as any }));
+      expect(r.ok).toBe(true);
+      // run_events row written for the new type
+      expect(queries.some((q) =>
+        q.sql.includes('INSERT INTO run_events') && q.params[1] === 'workflow.cancelled',
+      )).toBe(true);
+    });
+  });
 });

--- a/backend/src/workflows/adapters/n8n/n8n-webhook.controller.ts
+++ b/backend/src/workflows/adapters/n8n/n8n-webhook.controller.ts
@@ -76,7 +76,7 @@ export class N8nWebhookController {
   async receive(
     @Headers(SECRET_HEADER) secretHeader: string | undefined,
     @Body() body: N8nWebhookEvent,
-  ): Promise<{ ok: true; deduped?: boolean }> {
+  ): Promise<{ ok: true; deduped?: boolean; cancelled?: boolean }> {
     if (!verifyStaticSecret(secretHeader, this.webhookSecret)) {
       throw new UnauthorizedException('Invalid webhook secret');
     }
@@ -108,7 +108,8 @@ export class N8nWebhookController {
           payload: body.payload ?? null,
         },
       });
-      return { ok: true };
+      // No run context → cannot evaluate cancel state. Default false.
+      return { ok: true, cancelled: false };
     }
 
     if (!body.runId || !body.tenantId) {
@@ -129,6 +130,7 @@ export class N8nWebhookController {
       DEDUPE_NAMESPACE,
     );
 
+    let cancelled = false;
     const client = await this.pool.connect();
     try {
       await client.query('BEGIN');
@@ -147,11 +149,15 @@ export class N8nWebhookController {
         [eventId],
       );
       if (existing.rows.length > 0) {
+        // Even on dedup we must surface the current cancel state so the
+        // compiler-injected pre-ping can short-circuit on retry deliveries.
+        cancelled = await this.isCancelled(client, body.runId);
         await client.query('COMMIT');
-        return { ok: true, deduped: true };
+        return { ok: true, deduped: true, cancelled };
       }
 
       await this.applyEvent(client, body, eventId);
+      cancelled = await this.isCancelled(client, body.runId);
       await client.query('COMMIT');
     } catch (err) {
       await client.query('ROLLBACK');
@@ -178,7 +184,21 @@ export class N8nWebhookController {
       metadata: { event: body.event, stepKey: body.stepKey, n8nExecutionId: body.n8nExecutionId },
     });
 
-    return { ok: true };
+    return { ok: true, cancelled };
+  }
+
+  /**
+   * Phase 2.5a cooperative-cancel signal: returns true iff the run is in
+   * `cancelled` status. Called per webhook delivery so the compiler-injected
+   * `__pre_*` ping response can drive the per-step `__cancel_check_*` IF.
+   * Cheap single-row lookup; relies on RLS scope already set on `client`.
+   */
+  private async isCancelled(client: PoolClient, runId: string): Promise<boolean> {
+    const res = await client.query(
+      `SELECT 1 FROM workflow_runs WHERE id = $1 AND status = 'cancelled' LIMIT 1`,
+      [runId],
+    );
+    return res.rows.length > 0;
   }
 
   private async applyEvent(
@@ -209,23 +229,51 @@ export class N8nWebhookController {
       );
       stepRunId = upsert.rows[0]?.id ?? null;
     } else if (body.event === 'workflow.started') {
+      // Don't flip cancelled/terminal runs back to running.
       await client.query(
-        `UPDATE workflow_runs SET status = 'running', started_at = COALESCE(started_at, now()), updated_at = now()
-         WHERE id = $1`,
+        `UPDATE workflow_runs
+           SET status = 'running',
+               started_at = COALESCE(started_at, now()),
+               updated_at = now()
+         WHERE id = $1
+           AND status NOT IN ('cancelled', 'succeeded', 'failed')`,
         [body.runId],
       );
     } else if (body.event === 'workflow.completed') {
+      // A cancel that fires concurrent with workflow.completed must win:
+      // the user asked to cancel and the system acknowledged it.
       await client.query(
-        `UPDATE workflow_runs SET status = 'succeeded', completed_at = now(), updated_at = now()
-         WHERE id = $1`,
+        `UPDATE workflow_runs
+           SET status = 'succeeded',
+               completed_at = now(),
+               updated_at = now()
+         WHERE id = $1
+           AND status NOT IN ('cancelled', 'failed', 'succeeded')`,
         [body.runId],
       );
     } else if (body.event === 'workflow.failed') {
       await client.query(
-        `UPDATE workflow_runs SET status = 'failed', completed_at = now(),
-           error_details = $2, updated_at = now()
-         WHERE id = $1`,
+        `UPDATE workflow_runs
+           SET status = 'failed',
+               completed_at = now(),
+               error_details = $2,
+               updated_at = now()
+         WHERE id = $1
+           AND status NOT IN ('cancelled', 'succeeded', 'failed')`,
         [body.runId, body.payload ?? {}],
+      );
+    } else if (body.event === 'workflow.cancelled') {
+      // Emitted by the compiler-injected __end_cancelled HTTP Request when
+      // the per-step IF detects cancel. Idempotent: only stamps completed_at
+      // if the run was still pending/running. The cancel endpoint already
+      // flipped status to 'cancelled' synchronously; this writes the audit
+      // breadcrumb that confirms n8n actually halted.
+      await client.query(
+        `UPDATE workflow_runs
+           SET completed_at = COALESCE(completed_at, now()),
+               updated_at = now()
+         WHERE id = $1 AND status = 'cancelled'`,
+        [body.runId],
       );
     }
 

--- a/backend/src/workflows/adapters/n8n/n8n-webhook.dto.ts
+++ b/backend/src/workflows/adapters/n8n/n8n-webhook.dto.ts
@@ -28,6 +28,7 @@ export class N8nWebhookEventDto {
       'workflow.started',
       'workflow.completed',
       'workflow.failed',
+      'workflow.cancelled',
       'step.started',
       'step.completed',
     ],
@@ -71,4 +72,13 @@ export class N8nWebhookResponseDto {
     example: false,
   })
   deduped?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'Phase 2.5a cooperative-cancel signal. True iff `workflow_runs.status` is `cancelled`. ' +
+      'The compiler-injected `__pre_*` ping reads this and routes the next step through the ' +
+      '`__cancel_check_*` IF node to `__end_cancelled` instead of the canonical step.',
+    example: false,
+  })
+  cancelled?: boolean;
 }

--- a/backend/src/workflows/adapters/n8n/types.ts
+++ b/backend/src/workflows/adapters/n8n/types.ts
@@ -56,6 +56,7 @@ export type N8nWebhookEventType =
   | 'workflow.started'
   | 'workflow.completed'
   | 'workflow.failed'
+  | 'workflow.cancelled'
   | 'step.started'
   | 'step.completed';
 
@@ -63,11 +64,17 @@ export type N8nWebhookEventType =
  * Runtime tuple of every allowed webhook event type.
  * Derive N8nWebhookEventType from this so there is a single source of truth
  * that works at both compile time (the union type) and runtime (the array).
+ *
+ * Phase 2.5a adds `workflow.cancelled`: emitted by the compiler-injected
+ * `__end_cancelled` HTTP Request node after a per-step `__pre_*` ping reads
+ * `{ cancelled: true }` from the webhook response and routes through the
+ * `__cancel_check_*` IF node's true branch.
  */
 export const WEBHOOK_EVENT_TYPES = [
   'workflow.started',
   'workflow.completed',
   'workflow.failed',
+  'workflow.cancelled',
   'step.started',
   'step.completed',
 ] as const satisfies ReadonlyArray<N8nWebhookEventType>;

--- a/backend/src/workflows/workflows.module.ts
+++ b/backend/src/workflows/workflows.module.ts
@@ -3,6 +3,7 @@ import { AuditModule } from '@/audit/audit.module';
 import { AuthModule } from '@/auth/auth.module';
 import { N8nApiClient } from './adapters/n8n/n8n-api.client';
 import { N8nSyncService } from './adapters/n8n/n8n-sync.service';
+import { N8nExecutionAdapter } from './adapters/n8n/n8n-execution.adapter';
 import { N8nWebhookController } from './adapters/n8n/n8n-webhook.controller';
 import { WorkflowsController } from './workflows.controller';
 import { WorkflowsService } from './workflows.service';
@@ -30,10 +31,11 @@ import { ServiceAccountThrottlerGuard } from './guards/service-account-throttler
   providers: [
     N8nApiClient,
     N8nSyncService,
+    N8nExecutionAdapter,
     WorkflowsService,
     ProposalsService,
     ServiceAccountThrottlerGuard,
   ],
-  exports: [N8nSyncService, WorkflowsService, ProposalsService],
+  exports: [N8nSyncService, N8nExecutionAdapter, N8nApiClient, WorkflowsService, ProposalsService],
 })
 export class WorkflowsModule {}

--- a/docs/wiki/Workflow-Control-Plane.md
+++ b/docs/wiki/Workflow-Control-Plane.md
@@ -168,6 +168,64 @@ Every mutation writes exactly one `audit_events` row:
 | `workflow.published` | publish ok or sync failed | `priorActiveId`, `syncAction`, `syncError?` |
 | `workflow.rolled_back` | rollback ok or sync failed | `fromVersionId`, `toVersionId`, `syncError?` |
 | `workflow.proposal.created` | `POST /v1/workflow-proposals` | `parentVersionId`, `proposalSource`, `stepRunId`, `workflowRunId`, `errorFingerprint`, `canonicalHash` |
+| `workflow.run.started` | `POST /v1/workflow-runs` | `workflowVersionId`, `providerExecutionId`, `n8nWorkflowId` |
+| `workflow.run.cancelled` | `POST /v1/workflow-runs/:id/cancel` | `providerExecutionId` (cooperative cancel — see below) |
+| `workflow.run.failure_trigger_created` | failure hook landed a `proposal_triggers` row | `workflow_run_id`, `step_run_id`, `error_fingerprint` |
+| `failure_hook.skipped_no_provider_id` | failure with no stashed `providerExecutionId` | `reason` |
+
+---
+
+## Run lifecycle (Phase 2.5a)
+
+### Endpoints
+
+| Method | Path | Auth | Notes |
+|---|---|---|---|
+| `POST` | `/v1/workflow-runs` | User/service JWT | Body: `CreateWorkflowRunDto`. Triggers n8n via `POST /api/v1/workflows/:id/run` and stashes `{providerExecutionId, n8nWorkflowId}` on `workflow_runs.input.__provider`. Returns the run row. |
+| `GET` | `/v1/workflow-runs/:id` | User/service JWT | Returns `{run, steps, counts}`. RLS-scoped. |
+| `GET` | `/v1/workflow-runs/:id/events` | User/service JWT | SSE stream. Pass `Last-Event-ID: <int>` on reconnect to resume. |
+| `POST` | `/v1/workflow-runs/:id/cancel` | `@Roles('admin')` | Cooperative cancel — see below. |
+
+### SSE event types
+
+| Type | When |
+|---|---|
+| `workflow.started`, `workflow.completed`, `workflow.failed` | terminal/lifecycle from n8n webhook |
+| `workflow.cancelled` | the compiler-injected `__end_cancelled` node fires after a cooperative cancel |
+| `step.started`, `step.completed` | from `__pre_*` / `__post_*` ping nodes |
+| `workflow.reconciled` | best-effort post-failure / post-completion reconcile against n8n `/executions/:id` |
+| `ping` | server heartbeat every `SSE_HEARTBEAT_MS` (default 15 s); clients can ignore |
+
+### Reconnect contract
+
+Each `MessageEvent.id` is the monotonic `run_events.sequence`. Standard `EventSource` preserves it as the `Last-Event-ID` header on auto-reconnect, which the server reads and backfills `WHERE sequence > lastEventId`. The backfill phase runs against the connection pool with `SET LOCAL app.tenant_id`; the live phase pulls from a dedicated long-lived `LISTEN run_events` client and re-fetches each row through the pool (RLS-scoped). De-dupe on `sequence` covers the backfill→live overlap.
+
+> **Frontend gotcha (deferred to Phase 6):** Native `EventSource` cannot send `Authorization` headers. Backend integration tests use the Node `eventsource` package which supports headers; the production frontend will need cookie-JWT or a one-shot signed-URL pattern. Tracked separately.
+
+### Cooperative cancellation
+
+n8n v1.79.0's `POST /executions/:id/stop` returns 404 in self-hosted ([n8n-io/n8n#14748](https://github.com/n8n-io/n8n/issues/14748)). We work around this by extending the compiler:
+
+1. Every step gets a `__pre_<id>` HTTP-Request ping (existing) and a new `__cancel_check_<id>` n8n-`if` v2 node.
+2. The webhook handler that receives `__pre_*` now returns `{ ok, cancelled }` where `cancelled = (workflow_runs.status = 'cancelled')`.
+3. `__cancel_check_<id>` reads `$json.cancelled`. Output 0 (true) routes to a single shared `__end_cancelled` HTTP Request that posts `workflow.cancelled`; output 1 (false) routes to the canonical step.
+
+So calling `POST /v1/workflow-runs/:id/cancel` flips `workflow_runs.status` synchronously; the next step the n8n flow tries to run reads `cancelled=true` from its pre-ping and short-circuits. There's a small race window (n8n may complete a step between the cancel call and the next ping) — webhook status transitions guard with `WHERE status NOT IN ('cancelled','succeeded','failed')` so a `workflow.completed` arriving after `cancelled` can't flip the state back.
+
+### Failure → proposal hook
+
+Migration 013 adds an `AFTER INSERT` trigger on `run_events` that `pg_notify`s `run_events` channel with a compact payload. `SseSubscriberService` owns the single `LISTEN` connection and re-emits payloads on an in-process `EventEmitter` so `FailureHookService` doesn't need a second long-lived client.
+
+`FailureHookService` filters for `workflow.failed`, takes a `pg_try_advisory_xact_lock` keyed on the run id (multi-pod safety), then:
+
+1. Calls `N8nApiClient.getExecution(providerExecutionId)?includeData=true`.
+2. Walks `data.resultData.runData` for per-node `error`s.
+3. Resolves each failed n8n node to a `step_runs` row via `step_key === nodeName`.
+4. Computes `error_fingerprint = sha1(name:message)[:16]` and `last_successful_checkpoint` from the most recent `step.completed` event.
+5. `INSERT … INTO proposal_triggers (…) ON CONFLICT (workflow_run_id, COALESCE(step_run_id, zero-uuid), error_fingerprint) WHERE status='pending' DO NOTHING` — covered by migration 013's partial unique index.
+6. One audit row per inserted trigger.
+
+The agent worker that drains `proposal_triggers` and calls `POST /v1/workflow-proposals` is **not** part of 2.5a — it's a separate sub-issue.
 
 ---
 


### PR DESCRIPTION
## Parent

- Issue: #45 (split — backend slice; CI/preview pipeline is a follow-up sub-issue)
- Phase tracker: #25
- Plan: `C:\Users\vicky\.claude\plans\https-github-com-rinzler-vicky-agent-iss-peppy-bonbon.md`

## Summary

This is **Phase 2.5a — backend execution engine** on top of the Phase 2.3 n8n adapter. Closes the Class C self-modification loop on the backend side: a published workflow can now be invoked, watched in real time, cancelled, and a failure auto-files a `proposal_triggers` row so an agent worker (deferred) can draft a recovery patch.

The remaining surface of issue #45 — branch-preview CI pipeline, agent-initiated previews, the agent worker that drains `proposal_triggers`, the n8n-restart resilience test, and the production frontend SSE auth — are filed as follow-up sub-issues per the user's "deferred = sub-issue" rule. `Closes #45 in part`.

## Changed surfaces

- `backend/db/migrations/013_run_events_notify_trigger.sql` (+ `_rollback_down.sql`) — AFTER INSERT trigger publishing a compact `pg_notify('run_events', ...)` payload; partial unique index on `proposal_triggers` for failure-hook idempotency.
- `backend/scripts/migrate.js` — rollback list updated.
- `backend/src/runs/` (new module):
  - `RunsModule` wired into `AppModule`.
  - `RunsController` — `POST/GET/cancel /v1/workflow-runs` + `@Sse(':id/events')` reading `Last-Event-ID` header.
  - `RunsService` — txn-safe create (INSERT → trigger → stash → audit → COMMIT, ROLLBACK on adapter error); cooperative cancel.
  - `SseSubscriberService` — owns the single long-lived `LISTEN run_events` `pg.Client`. Backfills via the pool, fans out to per-run RxJS Subjects, exposes an in-process `EventEmitter` bridge for `FailureHookService`. Heartbeat + bounded exponential reconnect.
  - `FailureHookService` — on `workflow.failed`, reconciles n8n `/executions/:id?includeData=true`, walks per-node `runData`, writes one `proposal_triggers` row per failed step with `pg_try_advisory_xact_lock` + partial-index ON CONFLICT DO NOTHING.
- `backend/src/workflows/adapters/n8n/`:
  - `N8nExecutionAdapter` — `triggerExecution(...)` via `POST /api/v1/workflows/:id/run` + `listExecutions` fallback.
  - `N8nApiClient` — adds `runWorkflow`, `listExecutions`.
  - `n8n-compiler.ts` — injects `__cancel_check_<id>` (n8n IF v2) after each `__pre_*` ping, routing true → single shared `__end_cancelled` HTTP Request, false → canonical step.
  - `n8n-webhook.controller.ts` — response shape now `{ ok, deduped?, cancelled }`; handles new `workflow.cancelled` event; all status transitions guarded with `WHERE status NOT IN ('cancelled','succeeded','failed')`.
  - `types.ts` / `n8n-webhook.dto.ts` — `workflow.cancelled` added.
- `backend/.env.example` — new vars `N8N_TRIGGER_TIMEOUT_MS`, `N8N_TRIGGER_LIST_FALLBACK_DELAY_MS`, `SSE_HEARTBEAT_MS`.
- `docs/wiki/Workflow-Control-Plane.md` — new "Run lifecycle (Phase 2.5a)" section.
- `.agentic/STATE.md` — phase + decisions + completed-tasks log.

## Architecture decisions

| Decision | Choice | Why |
|---|---|---|
| Feature flag | None — auth-only | Matches commit `78997a3` removing `WORKFLOW_CONTROL_PLANE_ENABLED` |
| Trigger | `POST /api/v1/workflows/:id/run` + listExecutions fallback | Verified against [n8n community](https://community.n8n.io/t/executing-a-workflow-via-api-call-without-webhook-or-cli-command/212895); response `executionId` is best-effort |
| Cancel | Cooperative via compiler IF | n8n's `POST /executions/:id/stop` returns 404 in v1.79.0 ([n8n-io/n8n#14748](https://github.com/n8n-io/n8n/issues/14748)) |
| SSE transport | `LISTEN/NOTIFY` wakeup, `run_events.sequence` for `Last-Event-ID` | Per ADR-0002 §Decision 7 |
| Failure hook | Reconcile from n8n on `workflow.failed`; one trigger per failed node | Avoids compiler change for per-step failure events |
| Hook delivery | Single LISTEN client, in-process EventEmitter bridge | Half the socket cost; one shutdown path |

## Validation evidence

- `pnpm test`: **216/216 passing** (was 176 at branch start; +40 new across 5 specs).
- `pnpm check:swagger`: clean.
- `npx tsc --noEmit -p tsconfig.json`: clean.
- `pnpm lint`: 113 warnings, **0 new**, all pre-existing.

## Risks

- **n8n trigger reliability**: community thread reports intermittent failures where `POST /workflows/:id/run` returns 2xx without firing. Mitigated by the 500 ms `listExecutions` fallback. Will need real-traffic monitoring.
- **Cooperative cancel race window**: n8n may complete a step between cancel call and the next ping. Status transitions guard against the race; the worst case is `workflow.completed` is suppressed and the run stays `cancelled`.
- **Multi-pod hook idempotency**: covered by advisory lock + partial unique index, but the cross-pod chaos test is deferred to Phase 2.5b/3.

## Rollback plan

- `pnpm --filter @agent/backend migrate down` (rollback 013 → 012 → 006).
- Revert this PR — the `RunsModule` is unreferenced by anything else, no DB state migrates back to old schemas.
- The compiler IF injection is byte-stable; reverting the compiler change will re-trigger the workflow_adapter_artifacts cache to recompile, which is safe.

## Follow-up sub-issues (to file under #45 / #25)

1. **[Phase 2.5b]** Branch-preview CI pipeline + agent-initiated previews (child of #25).
2. **[Phase 2.5]** Agent worker that drains `proposal_triggers` (child of #45).
3. **[Phase 2.5]** n8n main-process restart resilience test (child of #45).
4. **[Phase 6]** SSE frontend auth pattern (cookie-JWT or signed URL).
5. **[Track upstream]** Replace cooperative cancel with REST hard-stop when n8n ships it.

## Test plan

- [ ] Apply migration 013 against a Neon branch with `pnpm migrate`.
- [ ] Manually publish a tiny workflow and POST `/v1/workflow-runs`; verify the run row + provider id stash.
- [ ] Open SSE with `curl -N /v1/workflow-runs/:id/events -H "Authorization: Bearer ..."`; verify backfill + heartbeat.
- [ ] Reconnect with `Last-Event-ID: 3`; verify only events with sequence > 3 are emitted.
- [ ] Mid-flight: `POST /v1/workflow-runs/:id/cancel`; verify the next `__pre_*` ping short-circuits.
- [ ] Induce a failure: verify `proposal_triggers` row lands + audit chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)